### PR TITLE
Add information about current runtime for check

### DIFF
--- a/resman.py
+++ b/resman.py
@@ -180,6 +180,8 @@ usage for the time being.")
             if dat['duration'] == -1:
                 print("Time remaining: indeterminate (waiting for command to \
 terminate)")
+                runtime = int(time.time()) - dat['start_time']
+                print(f"Time since job started: {secs2timestring(runtime)}")
             else:
                 snds = int(dat['start_time'] + dat['duration'] - time.time())
                 print(f"Time remaining: {secs2timestring(snds)}")


### PR DESCRIPTION
When using `resman -c`, you get some info about the potentially running job. This job might not have a duration (eg. instead running a command), and then it is hard to have any idea of when to check again for availability.

This commit outputs one extra line to `resman -c` in case the current running job does not have a duration: One which shows for how long the current job has ran so far. If this is several minutes, you don't have to check back in every few seconds.