### PR TITLE
Improve readability of time string

### DIFF
--- a/resman.py
+++ b/resman.py
@@ -95,7 +95,15 @@ def secs2timestring(snds: int):
     hours = snds // 3600
     mins = (snds := snds % 3600) // 60
     secs = snds % 60
-    return f"{hours}h{mins}m{secs}s"
+
+    timestring = ""
+    if hours:
+        timestring += f"{hours}h "
+    if hours or mins:
+        timestring += f"{mins}m "
+    timestring += f"{secs}s"
+
+    return timestring
 
 
 # Give a human readable explanation of data taken from the lock file.


### PR DESCRIPTION
This adds spaces between the times in timestring (`1h2m3s` -> `1h 2m 3s`). It also does not show hours or minutes if they are zero (`0h0m59s` -> `59s`).

The intention is that this will lead to a more user-friendly format. However, this is a personal preference, so I understand if this is not merged.