### PR TITLE
Create pre-commit hook configuration to run black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 24.2.0
+    hooks:
+      - id: black

--- a/README.md
+++ b/README.md
@@ -35,4 +35,5 @@ $ python3 -m venv venv
 $ source venv/bin/activate
 
 (venv)$ pip install -e .[dev] 
+(venv)$ pre-commit install
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ version = "1.0.20240216"
 
 [project.optional-dependencies]
 dev = [
-    "black"
+    "black",
+    "pre-commit",
 ]
 
 [tool.black]


### PR DESCRIPTION
Add a git hook to automatically run black on every `git commit` using the [pre-commit](https://pre-commit.com/#intro) tool.

Using this is optional, but can be more convenient than waiting for CI to finish.