### PR TITLE
Add a red `!` to the prompt when system is reserved

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ cat ./prompt-alert.sh | sudo tee -a /etc/bash.bashrc.local > /dev/null
 cat ./prompt-alert.sh | sudo tee -a /etc/zsh.zshrc.local > /dev/null
 ```
 
+Alternatively you may `source path/to/prompt-alert.sh` at the end of your bashrc.
+
 # Development
 
 Install development dependencies inside a virtual environment:

--- a/README.md
+++ b/README.md
@@ -26,6 +26,28 @@ experiments at the same time.
 Can also be run with **no arguments**, to check status. Exits with 0 if not reserved, or 1 if
 currently reserved. Just `echo $?` afterwards.
 
+# System Installation
+
+Install the program with
+```shell
+sudo ./install.sh
+```
+
+## Optional shell integration
+
+To more easily see when someone is running, you can use the code from `prompt-alert.sh`, which
+sets the global environment variable `RESMAN_ALERT` to a red `!` when the system is reserved. This
+is updated every time you refresh the prompt. It also includes a new PS1 variable to include
+this alert into the default prompt.
+
+The 'RESMAN_ALERT' variable can also be manually included in custom prompts.
+
+For example, append this code to the end of `/etc/bash.bashrc.local` and `/etc/zsh.zshrc.local`:
+```shell
+cat ./prompt-alert.sh | sudo tee -a /etc/bash.bashrc.local > /dev/null
+cat ./prompt-alert.sh | sudo tee -a /etc/zsh.zshrc.local > /dev/null
+```
+
 # Development
 
 Install development dependencies inside a virtual environment:

--- a/prompt-alert.sh
+++ b/prompt-alert.sh
@@ -1,0 +1,26 @@
+# Set RESMAN_ALERT to a red `!` when the system is reserved
+update_resman_alert() {
+    local lock_file="/etc/res_lock"
+
+    # Check if the file exists and is not empty
+    if [ -s "$lock_file" ]; then
+        # Check the status of the lock
+        current_time=$(date +%s)
+        is_locked=$(python3 -c "import sys, json; data=json.load(sys.stdin); print(data.get('duration', 0) == -1 or data.get('start_time', 0) + data.get('duration', 0) > $current_time)" < "$lock_file")
+
+        if [ "$is_locked" = "True" ]; then
+            RESMAN_ALERT=$'\e[31m!\e[0m'
+        else
+            # Remove the old lock here, for faster future checks
+            truncate -s 0 /etc/res_lock
+            RESMAN_ALERT=""
+        fi
+    else
+        RESMAN_ALERT=""
+    fi
+}
+
+PS1='${RESMAN_ALERT}\u@\h:\w> '
+
+# Recompute RESMAN_ALERT every time the prompt is refreshed
+PROMPT_COMMAND="update_resman_alert;${PROMPT_COMMAND:+$PROMPT_COMMAND}"

--- a/prompt-alert.sh
+++ b/prompt-alert.sh
@@ -1,26 +1,13 @@
 # Set RESMAN_ALERT to a red `!` when the system is reserved
 update_resman_alert() {
-    local lock_file="/etc/res_lock"
-
-    # Check if the file exists and is not empty
-    if [ -s "$lock_file" ]; then
-        # Check the status of the lock
-        current_time=$(date +%s)
-        is_locked=$(python3 -c "import sys, json; data=json.load(sys.stdin); print(data.get('duration', 0) == -1 or data.get('start_time', 0) + data.get('duration', 0) > $current_time)" < "$lock_file")
-
-        if [ "$is_locked" = "True" ]; then
-            RESMAN_ALERT=$'\e[31m!\e[0m'
-        else
-            # Remove the old lock here, for faster future checks
-            truncate -s 0 /etc/res_lock
-            RESMAN_ALERT=""
-        fi
-    else
+    if resman; then
         RESMAN_ALERT=""
+    else
+        RESMAN_ALERT=$'\e[31m!\e[0m'
     fi
 }
 
-PS1='${RESMAN_ALERT}\u@\h:\w> '
+PS1='${RESMAN_ALERT}'$PS1
 
 # Recompute RESMAN_ALERT every time the prompt is refreshed
 PROMPT_COMMAND="update_resman_alert;${PROMPT_COMMAND:+$PROMPT_COMMAND}"

--- a/todo.md
+++ b/todo.md
@@ -3,7 +3,7 @@ Things that would be nice to do:
  - An option to put yourself in a queue to reserve the server, in the case that it's locked and several people want to use it next.
  - Integrate it into Linux:
    - ~~A warning message at user login, that lets them know if someone is already running an experiment.~~
-   - An optional bash prompt modification that adds a little (!) or something if an experiment is running.
+   - ~~An optional bash prompt modification that adds a little (!) or something if an experiment is running.~~
    - Use of `wall` or similar (maybe there's something a bit more modern) that tells everyone on the server when someone begins an experiment (though careful, this might get annoying, maybe there's a better way)
 
  - Look into cgroups to impose actual resource locking constraints. Chatgpt says we can do something like this:


### PR DESCRIPTION
This is done by updating the global `RESMAN_ALERT` every time the prompt is refreshed. This variable can also be included in custom prompts.

It updates the variable by checking the global lock file. This can be costly as it has to parse JSON, so it therefore truncates the file when the previous reservation has ended, making future checks faster. However, it does introduce some overhead when the server is reserved.