### PR TITLE
Cleanups and features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,10 @@ CLIENT_EXE=resman
 INSTALL_ROOT=/usr/local
 
 .PHONY: all
-all: $(BUILD)/resmand $(BUILD)/resman
+
+server: $(BUILD)/$(SERVER_EXE)
+client: $(BUILD)/$(CLIENT_EXE)
+all: server client
 
 $(BUILD)/$(SERVER_EXE): $(OBJS_SERVER)
 	@mkdir -p $(dir $@)

--- a/client/arg.c
+++ b/client/arg.c
@@ -160,6 +160,9 @@ error_t parser_dequeue(int key, char *arg, struct argp_state *state) { /*{{{*/
             printf("[info] Verbose mode enabled.\n");
             args->verbose = 1;
             break;
+        case 'f':
+            args->force = 1;
+            break;
         case ARGP_KEY_ARG:
             if (state->arg_num == 0) {
                 errno = 0;

--- a/client/client.c
+++ b/client/client.c
@@ -1,7 +1,6 @@
 // vim: fdm=marker
 #include "client.h"
 
-#include <argp.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/client/cmd.c
+++ b/client/cmd.c
@@ -447,11 +447,16 @@ int subcmd_release(int argc, char** argv) {// {{{
         return -1;
     }
 
-    if (stat.status == STATUS_OK) {
-        printf("Successfully released lock\n");
-    } else {
-        fprintf(stderr, "[error] Release failed (code %d)\n", stat.status);
-        return -1;
+    switch (stat.status) {
+        case STATUS_OK:
+            printf("Successfully released lock\n");
+            break;
+        case STATUS_REL_OK_SERVER_IDLE:
+            printf("Server is not currently locked, no lock to release.\n");
+            break;
+        default:
+            fprintf(stderr, "[error] Release failed (code %d)\n", stat.status);
+            return -1;
     }
 
     return 0;

--- a/client/cmd.c
+++ b/client/cmd.c
@@ -421,6 +421,7 @@ int subcmd_release(int argc, char** argv) {// {{{
     }
 
     req.req_type = IPCREQ_RELEASE;
+    req.rel.uid = getuid();
     req.rel.force = args.force;
 
     if ((soc = connect_to_server(socket_addr)) < 0) {

--- a/client/cmd.c
+++ b/client/cmd.c
@@ -50,6 +50,7 @@ static struct argp argp_check = {
 };
 
 static struct argp_option options_dequeue[] = {
+    {"force", 'f', 0, 0, "Even if target job belongs to different user.", 0},
     {"verbose", 'V', 0, 0, "Give verbose output.", 0},
     {0,         0,   0, 0, 0,                      0},
 };
@@ -362,7 +363,7 @@ int subcmd_check(int argc UNUSED, char** argv UNUSED) { /*{{{*/
 } /*}}}*/
 
 int subcmd_dequeue(int argc, char** argv) { /*{{{*/
-    struct args_dequeue args = {.job_id = -1, .verbose = 0};
+    struct args_dequeue args = {.job_id = -1, .force = 0, .verbose = 0};
     ipc_request req;
     status_response stat;
     int soc;
@@ -384,6 +385,7 @@ int subcmd_dequeue(int argc, char** argv) { /*{{{*/
     req.req_type = IPCREQ_DEQUEUE;
     req.deq.uid = getuid();
     req.deq.job_uuid = args.job_id;
+    req.deq.force = args.force;
 
     if ((soc = connect_to_server(socket_addr)) < 0) {
         fprintf(stderr, "[error] Failed to connect to daemon.\n");

--- a/client/cmd.c
+++ b/client/cmd.c
@@ -253,8 +253,8 @@ int subcmd_time(int argc, char** argv) { /*{{{*/
 
     if (resp.status != STATUS_OK) {
         fprintf(stderr,
-                "Could not reserve time slot. Perhaps the server is already in "
-                "use?");
+                "[error] Could not reserve timeslot. Perhaps the server "
+                "is already in use?\n");
         return -1;
     }
 

--- a/client/cmd.c
+++ b/client/cmd.c
@@ -454,6 +454,9 @@ int subcmd_release(int argc, char** argv) {// {{{
         case STATUS_REL_OK_SERVER_IDLE:
             printf("Server is not currently locked, no lock to release.\n");
             break;
+        case STATUS_REL_FAIL_NOT_YOUR_JOB:
+            fprintf(stderr, "[error] Refusing to release lock held by another user, consider using --force.\n");
+            break;
         default:
             fprintf(stderr, "[error] Release failed (code %d)\n", stat.status);
             return -1;

--- a/client/cmd.c
+++ b/client/cmd.c
@@ -382,6 +382,7 @@ int subcmd_dequeue(int argc, char** argv) { /*{{{*/
     }
 
     req.req_type = IPCREQ_DEQUEUE;
+    req.deq.uid = getuid();
     req.deq.job_uuid = args.job_id;
 
     if ((soc = connect_to_server(socket_addr)) < 0) {
@@ -408,6 +409,9 @@ int subcmd_dequeue(int argc, char** argv) { /*{{{*/
             break;
         case STATUS_DEQ_FAIL_NO_SUCH_JOB:
             fprintf(stderr, "[error] Failed to dequeue job %d: job not found in queue\n", args.job_id);
+            break;
+        case STATUS_DEQ_FAIL_NOT_YOUR_JOB:
+            fprintf(stderr, "[error] Failed to dequeue job %d submitted by another user\n", args.job_id);
             break;
         default:
             fprintf(stderr, "[error] Dequeue failed (code: %d)\n", stat.status);

--- a/client/cmd.c
+++ b/client/cmd.c
@@ -33,7 +33,7 @@ static struct argp_option options_time[] = {
 
 static struct argp argp_time = {
     options_time, &parser_time,
-    "DURATION",   "Reserves the server for some time.",
+    "DURATION",   "Reserves the server for the given amount of time, specified using suffixes 's', 'm', or 'h' to specify seconds, minutes, or hours. These can be combined (e.g. 3h10m5s).",
     NULL,         NULL,
     NULL};
 

--- a/client/cmd.c
+++ b/client/cmd.c
@@ -424,7 +424,7 @@ int subcmd_release(int argc, char** argv) {// {{{
     req.rel.force = args.force;
 
     if ((soc = connect_to_server(socket_addr)) < 0) {
-        fprintf(stderr, "[error] Failed to connect to daemon.\n");
+        fprintf(stderr, "[error] Failed to connect to daemon\n");
         return -1;
     }
 
@@ -439,9 +439,9 @@ int subcmd_release(int argc, char** argv) {// {{{
     }
 
     if (stat.status == STATUS_OK) {
-        printf("Succesfully released lock.\n");
+        printf("Successfully released lock\n");
     } else {
-        printf("Release failed. Status = %d\n", stat.status);
+        fprintf(stderr, "[error] Release failed (code %d)\n", stat.status);
         return -1;
     }
 

--- a/client/cmd.c
+++ b/client/cmd.c
@@ -208,14 +208,13 @@ int subcmd_time(int argc, char** argv) { /*{{{*/
 
     argp_parse(&argp_time, argc - 1, argv + 1, 0, 0, (void*)&args);
 
-    if (args.verbose) {
-        if (args.seconds <= 0) {
-            fprintf(stderr, "No duration was given.\n");
-            return -1;
-        } else {
-            printf("Duration: %d seconds\n", args.seconds);
-        }
+    if (args.seconds <= 0) {
+        fprintf(stderr, "[error] Invalid duration, must be > 0 seconds.\n");
+        return -1;
+    }
 
+    if (args.verbose) {
+        printf("Duration: %d seconds\n", args.seconds);
         if (args.msg) {
             printf("Message: %s\n", args.msg);
         } else {

--- a/client/cmd.c
+++ b/client/cmd.c
@@ -382,7 +382,7 @@ int subcmd_dequeue(int argc, char** argv) { /*{{{*/
     }
 
     req.req_type = IPCREQ_DEQUEUE;
-    req.deq.job_uuid = (uuid_t)args.job_id;
+    req.deq.job_uuid = args.job_id;
 
     if ((soc = connect_to_server(socket_addr)) < 0) {
         fprintf(stderr, "[error] Failed to connect to daemon.\n");
@@ -399,11 +399,19 @@ int subcmd_dequeue(int argc, char** argv) { /*{{{*/
         return -1;
     }
 
-    if (stat.status == STATUS_OK) {
-        printf("Succesfully dequeued job %d\n", args.job_id);
-    } else {
-        printf("Dequeue failed. Status = %d\n", stat.status);
-        return -1;
+    switch (stat.status) {
+        case STATUS_OK:
+            printf("Successfully dequeued job %d\n", args.job_id);
+            break;
+        case STATUS_DEQ_FAIL_JOB_CURRENTLY_RUNNING:
+            fprintf(stderr, "[error] Cannot dequeue currently running job. Consider releasing the lock instead.\n");
+            break;
+        case STATUS_DEQ_FAIL_NO_SUCH_JOB:
+            fprintf(stderr, "[error] Failed to dequeue job %d: job not found in queue\n", args.job_id);
+            break;
+        default:
+            fprintf(stderr, "[error] Dequeue failed (code: %d)\n", stat.status);
+            return -1;
     }
 
     return 0;

--- a/include/client.h
+++ b/include/client.h
@@ -45,6 +45,7 @@ struct args_check {
 
 struct args_dequeue {
     uuid_t job_id;
+    int force;
     int verbose;
 };
 

--- a/include/client.h
+++ b/include/client.h
@@ -1,7 +1,9 @@
 // vim: fdm=marker
 #ifndef CLIENT_H
 #define CLIENT_H
+
 #include <argp.h>
+
 #include "resman.h"
 
 #define CLIENT_VER_STRING "0.0"

--- a/include/resman.h
+++ b/include/resman.h
@@ -58,6 +58,7 @@ typedef struct info_request {
 } info_request;
 
 typedef struct dequeue_request {
+    uid_t uid;
     uuid_t job_uuid;
 } dequeue_request;
 
@@ -79,6 +80,7 @@ typedef struct status_response {
         // Dequeue request failure types
         STATUS_DEQ_FAIL_JOB_CURRENTLY_RUNNING,
         STATUS_DEQ_FAIL_NO_SUCH_JOB,
+        STATUS_DEQ_FAIL_NOT_YOUR_JOB,
         // Release request status types
         STATUS_REL_OK_SERVER_IDLE,
         STATUS_REL_FAIL_NOT_YOUR_JOB,

--- a/include/resman.h
+++ b/include/resman.h
@@ -62,6 +62,7 @@ typedef struct dequeue_request {
 } dequeue_request;
 
 typedef struct release_request {
+    uid_t uid;
     int force;
 } release_request;
 

--- a/include/resman.h
+++ b/include/resman.h
@@ -76,6 +76,9 @@ typedef struct status_response {
     enum {
         STATUS_OK,
         STATUS_FAIL,
+        // Dequeue request failure types
+        STATUS_DEQ_FAIL_JOB_CURRENTLY_RUNNING,
+        STATUS_DEQ_FAIL_NO_SUCH_JOB,
     } status;
 } status_response;
 

--- a/include/resman.h
+++ b/include/resman.h
@@ -81,6 +81,7 @@ typedef struct status_response {
         STATUS_DEQ_FAIL_NO_SUCH_JOB,
         // Release request status types
         STATUS_REL_OK_SERVER_IDLE,
+        STATUS_REL_FAIL_NOT_YOUR_JOB,
     } status;
 } status_response;
 

--- a/include/resman.h
+++ b/include/resman.h
@@ -60,6 +60,7 @@ typedef struct info_request {
 typedef struct dequeue_request {
     uid_t uid;
     uuid_t job_uuid;
+    int force;
 } dequeue_request;
 
 typedef struct release_request {

--- a/include/resman.h
+++ b/include/resman.h
@@ -79,6 +79,8 @@ typedef struct status_response {
         // Dequeue request failure types
         STATUS_DEQ_FAIL_JOB_CURRENTLY_RUNNING,
         STATUS_DEQ_FAIL_NO_SUCH_JOB,
+        // Release request status types
+        STATUS_REL_OK_SERVER_IDLE,
     } status;
 } status_response;
 

--- a/include/server.h
+++ b/include/server.h
@@ -9,8 +9,8 @@
 #define LISTEN_QUEUE 8
 #define POLL_DELAY 2
 
-#define RESMAND_INFO(...) printf("[info]" __VA_ARGS__); fflush(stdout);
-#define RESMAND_ERROR(...) printf("[error!]" __VA_ARGS__); fflush(stdout);
+#define RESMAND_INFO(...) printf("[info] " __VA_ARGS__); fflush(stdout);
+#define RESMAND_ERROR(...) printf("[error!] " __VA_ARGS__); fflush(stdout);
 
 /* Thin wrapper around job descriptor for server-only fields */
 typedef struct queued_job {

--- a/include/server.h
+++ b/include/server.h
@@ -36,6 +36,7 @@ const queued_job *peek_job(queued_job *q, int off);
 queued_job *deq_job(queued_job **q);
 int enq_job(queued_job **q, job_descriptor job);
 int queue_len(queued_job *q);
+queued_job *find_job(queued_job **q, uuid_t uuid);
 queued_job *remove_job(queued_job **q, uuid_t uuid);
 int send_queue_info(int soc_client, unsigned int count);
 void disp_status(void);

--- a/include/server.h
+++ b/include/server.h
@@ -1,6 +1,10 @@
 // vim: fdm=marker
-#include "resman.h"
+#ifndef SERVER_H
+#define SERVER_H
+
 #include <pthread.h> /* pthread_mutex_* */
+
+#include "resman.h"
 
 #define LISTEN_QUEUE 8
 #define POLL_DELAY 2
@@ -35,3 +39,5 @@ int queue_len(queued_job *q);
 queued_job *remove_job(queued_job **q, uuid_t uuid);
 int send_queue_info(int soc_client, unsigned int count);
 void disp_status(void);
+
+#endif  /* SERVER_H */

--- a/include/server.h
+++ b/include/server.h
@@ -10,7 +10,7 @@
 #define POLL_DELAY 2
 
 #define RESMAND_INFO(...) printf("[info] " __VA_ARGS__); fflush(stdout);
-#define RESMAND_ERROR(...) printf("[error!] " __VA_ARGS__); fflush(stdout);
+#define RESMAND_ERROR(...) printf("[error] " __VA_ARGS__); fflush(stdout);
 
 /* Thin wrapper around job descriptor for server-only fields */
 typedef struct queued_job {

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -74,106 +74,109 @@ int handle_client(int soc_client) { /*{{{*/
         return -1;
     }
 
-    if (req.req_type == IPCREQ_JOB) {
-        job_descriptor job = req.job;
+    switch (req.req_type) {
+        case IPCREQ_JOB:
+            job_descriptor job = req.job;
 
-        if (job.job_type != JOB_CMD && job.job_type != JOB_TIMESLOT) {
-            RESMAND_ERROR("Invalid job type in request\n");
-            goto _close;
-        }
+            if (job.job_type != JOB_CMD && job.job_type != JOB_TIMESLOT) {
+                RESMAND_ERROR("Invalid job type in request\n");
+                goto _close;
+            }
 
-        job.job_uuid = next_uuid();
+            job.job_uuid = next_uuid();
 
-        switch (job.job_type) {
-            case JOB_CMD:
-                RESMAND_INFO(
-                    "Received command job %d by user %d (pid: %d, msg: '%s')\n",
-                    job.job_uuid, job.uid, job.cmd.pid, job.msg
-                );
-                pthread_mutex_lock(&mut_q);
-                enq_job(&q, job);
-                pthread_mutex_unlock(&mut_q);
-                resp.status = STATUS_OK;
-                break;
-            case JOB_TIMESLOT:
-                RESMAND_INFO(
-                    "Received timeslot job %d by user %d (time: %ds, msg: '%s')\n",
-                    job.job_uuid, job.uid, job.timeslot.secs, job.msg
-                );
-
-                if (running_job || peek_job(q, 0)) {
+            switch (job.job_type) {
+                case JOB_CMD:
                     RESMAND_INFO(
-                        "Rejecting timeslot job %d: server is already reserved\n",
-                        job.job_uuid
+                        "Received command job %d by user %d (pid: %d, msg: '%s')\n",
+                        job.job_uuid, job.uid, job.cmd.pid, job.msg
                     );
-                    resp.status = STATUS_FAIL;
+                    pthread_mutex_lock(&mut_q);
+                    enq_job(&q, job);
+                    pthread_mutex_unlock(&mut_q);
+                    resp.status = STATUS_OK;
                     break;
-                }
+                case JOB_TIMESLOT:
+                    RESMAND_INFO(
+                        "Received timeslot job %d by user %d (time: %ds, msg: '%s')\n",
+                        job.job_uuid, job.uid, job.timeslot.secs, job.msg
+                    );
 
-                pthread_mutex_lock(&mut_q);
-                enq_job(&q, job);
-                pthread_mutex_unlock(&mut_q);
-                resp.status = STATUS_OK;
-                break;
-        }
+                    if (running_job || peek_job(q, 0)) {
+                        RESMAND_INFO(
+                            "Rejecting timeslot job %d: server is already reserved\n",
+                            job.job_uuid
+                        );
+                        resp.status = STATUS_FAIL;
+                        break;
+                    }
 
-        send_status(soc_client, &resp);
-        disp_status();
-    } else if (req.req_type == IPCREQ_VIEW_QUEUE) {
-        info_request info = req.info;
-        send_queue_info(soc_client, info.n_view);
-    } else if (req.req_type == IPCREQ_DEQUEUE) {
-        dequeue_request deq = req.deq;
-        RESMAND_INFO("Received dequeue request for job %d\n", deq.job_uuid);
+                    pthread_mutex_lock(&mut_q);
+                    enq_job(&q, job);
+                    pthread_mutex_unlock(&mut_q);
+                    resp.status = STATUS_OK;
+                    break;
+            }
 
-        pthread_mutex_lock(&mut_rj);
-        pthread_mutex_lock(&mut_q);
+            send_status(soc_client, &resp);
+            break;
+        case IPCREQ_VIEW_QUEUE:
+            info_request info = req.info;
+            send_queue_info(soc_client, info.n_view);
+            break;
+        case IPCREQ_DEQUEUE:
+            dequeue_request deq = req.deq;
+            RESMAND_INFO("Received dequeue request for job %d\n", deq.job_uuid);
 
-        if (running_job && running_job->job.job_uuid == deq.job_uuid) {
-            RESMAND_ERROR("Refusing to dequeue currently running job\n")
-            resp.status = STATUS_DEQ_FAIL_JOB_CURRENTLY_RUNNING;
-        } else {
-            queued_job *deq_job = remove_job(&q, deq.job_uuid);
-            if (!deq_job) {
-                RESMAND_ERROR("Failed to dequeue job %d: not found in queue"
-                              "\n", deq.job_uuid);
-                resp.status = STATUS_DEQ_FAIL_NO_SUCH_JOB;
+            pthread_mutex_lock(&mut_rj);
+            pthread_mutex_lock(&mut_q);
+
+            if (running_job && running_job->job.job_uuid == deq.job_uuid) {
+                RESMAND_ERROR("Refusing to dequeue currently running job\n")
+                resp.status = STATUS_DEQ_FAIL_JOB_CURRENTLY_RUNNING;
             } else {
-                RESMAND_INFO("Dequeueueueueing job %d\n", deq_job->job.job_uuid);
-                free_queued_job(deq_job);
+                queued_job *deq_job = remove_job(&q, deq.job_uuid);
+                if (!deq_job) {
+                    RESMAND_ERROR("Failed to dequeue job %d: not found in queue"
+                                  "\n", deq.job_uuid);
+                    resp.status = STATUS_DEQ_FAIL_NO_SUCH_JOB;
+                } else {
+                    RESMAND_INFO("Dequeueueueueing job %d\n", deq_job->job.job_uuid);
+                    free_queued_job(deq_job);
+                    resp.status = STATUS_OK;
+                }
+            }
+
+            pthread_mutex_unlock(&mut_q);
+            pthread_mutex_unlock(&mut_rj);
+
+            send_status(soc_client, &resp);
+            break;
+        case IPCREQ_RELEASE:
+            release_request rel = req.rel;
+
+            if (!running_job) {
+                RESMAND_INFO("Received manual release request by user %d, but "
+                             "server is not reserved. Nothing to do.\n",
+                             rel.uid)
+                resp.status = STATUS_OK;
+            } else {
+                RESMAND_INFO("Received manual release request by user %d (force: "
+                             "%d), cancelling current running job %d\n",
+                             rel.uid, rel.force, running_job->job.job_uuid);
+                pthread_mutex_lock(&mut_rj);
+                running_job->manually_released = 1;
+                pthread_mutex_unlock(&mut_rj);
                 resp.status = STATUS_OK;
             }
-        }
-
-        pthread_mutex_unlock(&mut_q);
-        pthread_mutex_unlock(&mut_rj);
-
-        send_status(soc_client, &resp);
-
-        disp_status();
-    } else if (req.req_type == IPCREQ_RELEASE) {
-        release_request rel = req.rel;
-
-        if (!running_job) {
-            RESMAND_INFO("Received manual release request by user %d, but "
-                         "server is not reserved. Nothing to do.\n",
-                         rel.uid)
-            resp.status = STATUS_OK;
-        } else {
-            RESMAND_INFO("Received manual release request by user %d (force: "
-                         "%d), cancelling current running job %d\n",
-                         rel.uid, rel.force, running_job->job.job_uuid);
-            pthread_mutex_lock(&mut_rj);
-            running_job->manually_released = 1;
-            pthread_mutex_unlock(&mut_rj);
-            resp.status = STATUS_OK;
-        }
-        send_status(soc_client, &resp);
-    } else {
-        RESMAND_ERROR("Invalid request type: %d\n", req.req_type);
-        close(soc_client);
-        return -1;
+            send_status(soc_client, &resp);
+            break;
+        default:
+            RESMAND_ERROR("Invalid request type: %d\n", req.req_type);
+            close(soc_client);
+            return -1;
     }
+
 _close:
     close(soc_client);
 

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -121,11 +121,11 @@ int handle_client(int soc_client) { /*{{{*/
             send_status(soc_client, &resp);
             break;
         case IPCREQ_VIEW_QUEUE:
-            info_request info = req.info;
+            const info_request info = req.info;
             send_queue_info(soc_client, info.n_view);
             break;
         case IPCREQ_DEQUEUE:
-            dequeue_request deq = req.deq;
+            const dequeue_request deq = req.deq;
             RESMAND_INFO("Received dequeue request for job %d\n", deq.job_uuid);
 
             pthread_mutex_lock(&mut_rj);
@@ -153,7 +153,7 @@ int handle_client(int soc_client) { /*{{{*/
             send_status(soc_client, &resp);
             break;
         case IPCREQ_RELEASE:
-            release_request rel = req.rel;
+            const release_request rel = req.rel;
 
             if (!running_job) {
                 RESMAND_INFO("Received manual release request by user %d, but "

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -159,7 +159,7 @@ int handle_client(int soc_client) { /*{{{*/
                 RESMAND_INFO("Received manual release request by user %d, but "
                              "server is not reserved. Nothing to do.\n",
                              rel.uid)
-                resp.status = STATUS_OK;
+                resp.status = STATUS_REL_OK_SERVER_IDLE;
             } else {
                 RESMAND_INFO("Received manual release request by user %d (force: "
                              "%d), cancelling current running job %d\n",

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -141,13 +141,17 @@ int handle_client(int soc_client) { /*{{{*/
                     RESMAND_ERROR("Failed to dequeue job %d: not found in queue"
                                   "\n", deq.job_uuid);
                     resp.status = STATUS_DEQ_FAIL_NO_SUCH_JOB;
-                } else if (target_job->job.uid != deq.uid) {
-                    RESMAND_ERROR("Refusing to dequeue job %d owned by %d\n",
-                                  target_job->job.job_uuid, target_job->job.uid);
+                } else if (target_job->job.uid != deq.uid && !deq.force) {
+                    RESMAND_ERROR("Refusing to dequeue job %d owned by %d "
+                                  "(force: %d)\n",
+                                  target_job->job.job_uuid, target_job->job.uid,
+                                  deq.force);
                     resp.status = STATUS_DEQ_FAIL_NOT_YOUR_JOB;
                 } else {
-                    RESMAND_INFO("Dequeueueueueing job %d\n",
-                                 target_job->job.job_uuid);
+                    RESMAND_INFO("Dequeueueueueing job %d owned by %d (force: "
+                                 "%d)\n",
+                                 target_job->job.job_uuid, target_job->job.uid,
+                                 deq.force)
                     // This searches the queue again (cf. find_job above), but
                     // it's fine since we hold mut_q throughout
                     queued_job *deq_job = remove_job(&q, deq.job_uuid);

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -126,7 +126,8 @@ int handle_client(int soc_client) { /*{{{*/
             break;
         case IPCREQ_DEQUEUE:
             const dequeue_request deq = req.deq;
-            RESMAND_INFO("Received dequeue request for job %d\n", deq.job_uuid);
+            RESMAND_INFO("Received dequeue request for job %d from user %d\n",
+                         deq.job_uuid, deq.uid);
 
             pthread_mutex_lock(&mut_rj);
             pthread_mutex_lock(&mut_q);
@@ -135,13 +136,21 @@ int handle_client(int soc_client) { /*{{{*/
                 RESMAND_ERROR("Refusing to dequeue currently running job\n")
                 resp.status = STATUS_DEQ_FAIL_JOB_CURRENTLY_RUNNING;
             } else {
-                queued_job *deq_job = remove_job(&q, deq.job_uuid);
-                if (!deq_job) {
+                queued_job *target_job = find_job(&q, deq.job_uuid);
+                if (!target_job) {
                     RESMAND_ERROR("Failed to dequeue job %d: not found in queue"
                                   "\n", deq.job_uuid);
                     resp.status = STATUS_DEQ_FAIL_NO_SUCH_JOB;
+                } else if (target_job->job.uid != deq.uid) {
+                    RESMAND_ERROR("Refusing to dequeue job %d owned by %d\n",
+                                  target_job->job.job_uuid, target_job->job.uid);
+                    resp.status = STATUS_DEQ_FAIL_NOT_YOUR_JOB;
                 } else {
-                    RESMAND_INFO("Dequeueueueueing job %d\n", deq_job->job.job_uuid);
+                    RESMAND_INFO("Dequeueueueueing job %d\n",
+                                 target_job->job.job_uuid);
+                    // This searches the queue again (cf. find_job above), but
+                    // it's fine since we hold mut_q throughout
+                    queued_job *deq_job = remove_job(&q, deq.job_uuid);
                     free_queued_job(deq_job);
                     resp.status = STATUS_OK;
                 }

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -78,43 +78,42 @@ int handle_client(int soc_client) { /*{{{*/
         job_descriptor job = req.job;
 
         if (job.job_type != JOB_CMD && job.job_type != JOB_TIMESLOT) {
-            RESMAND_ERROR("Unrecognised job type in request.\n");
+            RESMAND_ERROR("Invalid job type in request\n");
             goto _close;
         }
 
         job.job_uuid = next_uuid();
-        if (job.job_type == JOB_CMD) {
-            RESMAND_INFO(
-                "Received command job %d by user %d (pid: %d, msg: '%s')\n",
-                job.job_uuid, job.uid, job.cmd.pid, job.msg
-            );
-        } else {
-            RESMAND_INFO(
-                "Received timeslot job %d by user %d (time: %ds, msg: '%s')\n",
-                job.job_uuid, job.uid, job.timeslot.secs, job.msg
-            );
-        }
 
         switch (job.job_type) {
             case JOB_CMD:
+                RESMAND_INFO(
+                    "Received command job %d by user %d (pid: %d, msg: '%s')\n",
+                    job.job_uuid, job.uid, job.cmd.pid, job.msg
+                );
                 pthread_mutex_lock(&mut_q);
                 enq_job(&q, job);
                 pthread_mutex_unlock(&mut_q);
                 resp.status = STATUS_OK;
                 break;
             case JOB_TIMESLOT:
+                RESMAND_INFO(
+                    "Received timeslot job %d by user %d (time: %ds, msg: '%s')\n",
+                    job.job_uuid, job.uid, job.timeslot.secs, job.msg
+                );
+
                 if (running_job || peek_job(q, 0)) {
                     RESMAND_INFO(
-                        "Rejecting timeslot job %d for user %d: server is "
-                        "already reserved.\n",
-                        job.job_uuid, job.uid);
+                        "Rejecting timeslot job %d: server is already reserved\n",
+                        job.job_uuid
+                    );
                     resp.status = STATUS_FAIL;
-                } else {
-                    pthread_mutex_lock(&mut_q);
-                    enq_job(&q, job);
-                    pthread_mutex_unlock(&mut_q);
-                    resp.status = STATUS_OK;
+                    break;
                 }
+
+                pthread_mutex_lock(&mut_q);
+                enq_job(&q, job);
+                pthread_mutex_unlock(&mut_q);
+                resp.status = STATUS_OK;
                 break;
         }
 

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -142,12 +142,14 @@ int handle_client(int soc_client) { /*{{{*/
         release_request rel = req.rel;
 
         if (!running_job) {
-            RESMAND_INFO("Received manual release request, but server is not "
-                         "reserved. Nothing to do.\n")
+            RESMAND_INFO("Received manual release request by user %d, but "
+                         "server is not reserved. Nothing to do.\n",
+                         rel.uid)
             resp.status = STATUS_OK;
         } else {
-            RESMAND_INFO("Received manual release request (force=%d), cancelling current running job %d\n",
-                         rel.force, running_job->job.job_uuid);
+            RESMAND_INFO("Received manual release request by user %d (force: "
+                         "%d), cancelling current running job %d\n",
+                         rel.uid, rel.force, running_job->job.job_uuid);
             pthread_mutex_lock(&mut_rj);
             running_job->manually_released = 1;
             pthread_mutex_unlock(&mut_rj);

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -140,16 +140,20 @@ int handle_client(int soc_client) { /*{{{*/
         disp_status();
     } else if (req.req_type == IPCREQ_RELEASE) {
         release_request rel = req.rel;
-        RESMAND_INFO("Received manual release request\n");
 
         if (!running_job) {
+            RESMAND_INFO("Received manual release request, but server is not "
+                         "reserved. Nothing to do.\n")
             resp.status = STATUS_OK;
         } else {
-            printf("Releasing lock. Force=%d\n", rel.force);
+            RESMAND_INFO("Received manual release request (force=%d), cancelling current running job %d\n",
+                         rel.force, running_job->job.job_uuid);
             pthread_mutex_lock(&mut_rj);
             running_job->manually_released = 1;
             pthread_mutex_unlock(&mut_rj);
+            resp.status = STATUS_OK;
         }
+        send_status(soc_client, &resp);
     } else {
         RESMAND_ERROR("Invalid request type: %d\n", req.req_type);
         close(soc_client);

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -85,13 +85,13 @@ int handle_client(int soc_client) { /*{{{*/
         job.job_uuid = next_uuid();
         if (job.job_type == JOB_CMD) {
             RESMAND_INFO(
-                "new job CMD(uid=%d job_uuid=%d pid=%d msg=%s)\n",
-                job.uid, job.job_uuid, job.cmd.pid, job.msg
+                "Received command job %d by user %d (pid: %d, msg: '%s')\n",
+                job.job_uuid, job.uid, job.cmd.pid, job.msg
             );
         } else {
             RESMAND_INFO(
-                "new job TIMESLOT(uid=%d job_uuid=%d time=%ds msg=%s)\n",
-                job.uid, job.job_uuid, job.timeslot.secs, job.msg
+                "Received timeslot job %d by user %d (time: %ds, msg: '%s')\n",
+                job.job_uuid, job.uid, job.timeslot.secs, job.msg
             );
         }
 
@@ -105,7 +105,7 @@ int handle_client(int soc_client) { /*{{{*/
             case JOB_TIMESLOT:
                 if (running_job || peek_job(q, 0)) {
                     RESMAND_INFO(
-                        "User %d wanted a timeslot, but server is "
+                        "User %d requested a timeslot, but server is "
                         "already reserved.\n",
                         job.uid);
                     resp.status = STATUS_FAIL;
@@ -125,13 +125,13 @@ int handle_client(int soc_client) { /*{{{*/
         send_queue_info(soc_client, info.n_view);
     } else if (req.req_type == IPCREQ_DEQUEUE) {
         dequeue_request deq = req.deq;
-        RESMAND_INFO("dequeue request (job_uuid=%d)\n", deq.job_uuid);
+        RESMAND_INFO("Received dequeue request for job %d\n", deq.job_uuid);
 
         pthread_mutex_lock(&mut_q);
         queued_job *deq_job = remove_job(&q, deq.job_uuid);
         pthread_mutex_unlock(&mut_q);
 
-        RESMAND_INFO("Dequeued job = %lu\n", (unsigned long)deq_job);
+        RESMAND_INFO("Dequeued job %lu\n", (unsigned long)deq_job);
 
         free_queued_job(deq_job);
         resp.status = deq_job ? STATUS_OK : STATUS_FAIL;
@@ -140,7 +140,7 @@ int handle_client(int soc_client) { /*{{{*/
         disp_status();
     } else if (req.req_type == IPCREQ_RELEASE) {
         release_request rel = req.rel;
-        RESMAND_INFO("release request\n");
+        RESMAND_INFO("Received manual release request\n");
 
         if (!running_job) {
             resp.status = STATUS_OK;
@@ -151,7 +151,7 @@ int handle_client(int soc_client) { /*{{{*/
             pthread_mutex_unlock(&mut_rj);
         }
     } else {
-        RESMAND_ERROR("Incorrect request type: %d\n", req.req_type);
+        RESMAND_ERROR("Invalid request type: %d\n", req.req_type);
         close(soc_client);
         return -1;
     }

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -155,20 +155,46 @@ int handle_client(int soc_client) { /*{{{*/
         case IPCREQ_RELEASE:
             const release_request rel = req.rel;
 
+            pthread_mutex_lock(&mut_rj);
+
             if (!running_job) {
                 RESMAND_INFO("Received manual release request by user %d, but "
                              "server is not reserved. Nothing to do.\n",
                              rel.uid)
                 resp.status = STATUS_REL_OK_SERVER_IDLE;
             } else {
-                RESMAND_INFO("Received manual release request by user %d (force: "
-                             "%d), cancelling current running job %d\n",
-                             rel.uid, rel.force, running_job->job.job_uuid);
-                pthread_mutex_lock(&mut_rj);
-                running_job->manually_released = 1;
-                pthread_mutex_unlock(&mut_rj);
-                resp.status = STATUS_OK;
+                if (running_job->job.uid == rel.uid) {
+                    // Requesting user owns the job, ok
+                    RESMAND_INFO("Received manual release request by user %d "
+                                 "for their currently running job %d, "
+                                 "releasing lock\n",
+                                 rel.uid, running_job->job.job_uuid);
+                    running_job->manually_released = 1;
+                    resp.status = STATUS_OK;
+                } else {
+                    // Requesting user does not own the job, require force
+                    if (rel.force) {
+                        RESMAND_INFO("Received manual release request by user "
+                                     "%d for current running job %d owned by "
+                                     "%d (force: %d), releasing lock\n",
+                                     rel.uid, running_job->job.uid,
+                                     running_job->job.job_uuid, rel.force);
+                        running_job->manually_released = 1;
+                        resp.status = STATUS_OK;
+                    } else {
+                        RESMAND_ERROR("Received manual release request by user "
+                                      "%d for current running job %d owned by "
+                                      "%d (force: %d), refusing to release "
+                                      "lock\n",
+                                      rel.uid, running_job->job.job_uuid,
+                                      running_job->job.uid, rel.force);
+                        resp.status = STATUS_REL_FAIL_NOT_YOUR_JOB;
+                    }
+                }
             }
+
+            pthread_mutex_unlock(&mut_rj);
+
             send_status(soc_client, &resp);
             break;
         default:

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -25,7 +25,7 @@ int make_soc_listen(const char *addr) { /*{{{*/
     sa_local.sun_family = AF_UNIX;
     sa_local.sun_path[0] = '\0';
     strncpy(sa_local.sun_path + 1, addr, strlen(addr));
-    
+
     sa_len = offsetof(struct sockaddr_un, sun_path) + 1 + strlen(addr);
 
     if (bind(soc_listen, (struct sockaddr *)&sa_local, sa_len) < 0) {
@@ -126,14 +126,28 @@ int handle_client(int soc_client) { /*{{{*/
         dequeue_request deq = req.deq;
         RESMAND_INFO("Received dequeue request for job %d\n", deq.job_uuid);
 
+        pthread_mutex_lock(&mut_rj);
         pthread_mutex_lock(&mut_q);
-        queued_job *deq_job = remove_job(&q, deq.job_uuid);
+
+        if (running_job && running_job->job.job_uuid == deq.job_uuid) {
+            RESMAND_ERROR("Refusing to dequeue currently running job\n")
+            resp.status = STATUS_DEQ_FAIL_JOB_CURRENTLY_RUNNING;
+        } else {
+            queued_job *deq_job = remove_job(&q, deq.job_uuid);
+            if (!deq_job) {
+                RESMAND_ERROR("Failed to dequeue job %d: not found in queue"
+                              "\n", deq.job_uuid);
+                resp.status = STATUS_DEQ_FAIL_NO_SUCH_JOB;
+            } else {
+                RESMAND_INFO("Dequeueueueueing job %d\n", deq_job->job.job_uuid);
+                free_queued_job(deq_job);
+                resp.status = STATUS_OK;
+            }
+        }
+
         pthread_mutex_unlock(&mut_q);
+        pthread_mutex_unlock(&mut_rj);
 
-        RESMAND_INFO("Dequeued job %lu\n", (unsigned long)deq_job);
-
-        free_queued_job(deq_job);
-        resp.status = deq_job ? STATUS_OK : STATUS_FAIL;
         send_status(soc_client, &resp);
 
         disp_status();

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -126,32 +126,34 @@ int handle_client(int soc_client) { /*{{{*/
             break;
         case IPCREQ_DEQUEUE:
             const dequeue_request deq = req.deq;
-            RESMAND_INFO("Received dequeue request for job %d from user %d\n",
-                         deq.job_uuid, deq.uid);
 
             pthread_mutex_lock(&mut_rj);
             pthread_mutex_lock(&mut_q);
 
             if (running_job && running_job->job.job_uuid == deq.job_uuid) {
-                RESMAND_ERROR("Refusing to dequeue currently running job\n")
+                RESMAND_ERROR("Received dequeue request by user %d for job %d, "
+                              "but refusing to dequeue currently running job\n",
+                              deq.uid, deq.job_uuid)
                 resp.status = STATUS_DEQ_FAIL_JOB_CURRENTLY_RUNNING;
             } else {
                 queued_job *target_job = find_job(&q, deq.job_uuid);
                 if (!target_job) {
-                    RESMAND_ERROR("Failed to dequeue job %d: not found in queue"
-                                  "\n", deq.job_uuid);
+                    RESMAND_ERROR("Received dequeue request by user %d for job "
+                                  "%d, but no such job in queue\n",
+                                  deq.uid, deq.job_uuid);
                     resp.status = STATUS_DEQ_FAIL_NO_SUCH_JOB;
                 } else if (target_job->job.uid != deq.uid && !deq.force) {
-                    RESMAND_ERROR("Refusing to dequeue job %d owned by %d "
-                                  "(force: %d)\n",
-                                  target_job->job.job_uuid, target_job->job.uid,
+                    RESMAND_ERROR("Received dequeue request by user %d for job "
+                                  "%d owned by %d (force: %d), refusing to "
+                                  "dequeue\n",
+                                  deq.uid, deq.job_uuid, target_job->job.uid,
                                   deq.force);
                     resp.status = STATUS_DEQ_FAIL_NOT_YOUR_JOB;
                 } else {
-                    RESMAND_INFO("Dequeueueueueing job %d owned by %d (force: "
-                                 "%d)\n",
-                                 target_job->job.job_uuid, target_job->job.uid,
-                                 deq.force)
+                    RESMAND_INFO("Received dequeue request by user %d for job "
+                                 "%d owned by %d (force: %d), dequeueing job\n",
+                                 deq.uid, deq.job_uuid, target_job->job.uid,
+                                 deq.force);
                     // This searches the queue again (cf. find_job above), but
                     // it's fine since we hold mut_q throughout
                     queued_job *deq_job = remove_job(&q, deq.job_uuid);

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -105,9 +105,9 @@ int handle_client(int soc_client) { /*{{{*/
             case JOB_TIMESLOT:
                 if (running_job || peek_job(q, 0)) {
                     RESMAND_INFO(
-                        "User %d requested a timeslot, but server is "
+                        "Rejecting timeslot job %d for user %d: server is "
                         "already reserved.\n",
-                        job.uid);
+                        job.job_uuid, job.uid);
                     resp.status = STATUS_FAIL;
                 } else {
                     pthread_mutex_lock(&mut_q);

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -127,8 +127,8 @@ int handle_client(int soc_client) { /*{{{*/
         case IPCREQ_DEQUEUE:
             const dequeue_request deq = req.deq;
 
-            pthread_mutex_lock(&mut_rj);
             pthread_mutex_lock(&mut_q);
+            pthread_mutex_lock(&mut_rj);
 
             if (running_job && running_job->job.job_uuid == deq.job_uuid) {
                 RESMAND_ERROR("Received dequeue request by user %d for job %d, "
@@ -162,8 +162,8 @@ int handle_client(int soc_client) { /*{{{*/
                 }
             }
 
-            pthread_mutex_unlock(&mut_q);
             pthread_mutex_unlock(&mut_rj);
+            pthread_mutex_unlock(&mut_q);
 
             send_status(soc_client, &resp);
             break;

--- a/server/queue.c
+++ b/server/queue.c
@@ -22,6 +22,17 @@ queued_job *deq_job(queued_job **q) { /*{{{*/
     return ret;
 } /*}}}*/
 
+/* Search the queue for a job with a given UUID. */
+queued_job *find_job(queued_job **q, const uuid_t uuid) {
+    for (queued_job *ret = *q; ret; ret = ret->next) {
+        if (uuid == ret->job.job_uuid) {
+            return ret;
+        }
+    }
+
+    return NULL; /* Not found */
+}
+
 /* Remove a job from the middle of the queue with a given UUID. */
 queued_job *remove_job(queued_job **q, uuid_t uuid) {/*{{{*/
     queued_job *ret = *q;

--- a/server/server.c
+++ b/server/server.c
@@ -51,7 +51,7 @@ int main(void) { /*{{{*/
     }
 
     if (pthread_create(&thr_dispatcher, NULL, &dispatcher, NULL) != 0) {
-        fprintf(stderr, "pthread_create failed!\n");
+        fprintf(stderr, "pthread_create failed\n");
         return EXIT_FAILURE;
     }
 
@@ -63,7 +63,7 @@ int main(void) { /*{{{*/
         }
 
         if (handle_client(soc_client) < 0) {
-            RESMAND_ERROR("Failed while handling a new client.\n");
+            RESMAND_ERROR("Failed while handling a new client\n");
         }
     }
 } /*}}}*/
@@ -93,7 +93,7 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
             switch (running_job->job.job_type) {
                 case JOB_TIMESLOT: {
                     if (running_job->manually_released || time(NULL) >= running_job->job.timeslot.t_end) {
-                        RESMAND_INFO("Timeslot job %d finished.\n",
+                        RESMAND_INFO("Timeslot job %d finished\n",
                                      running_job->job.job_uuid);
 
                         pthread_mutex_lock(&mut_rj);
@@ -159,7 +159,7 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
                 switch (running_job->job.job_type) {
                     case JOB_CMD:
                         RESMAND_INFO(
-                            "Starting command job %d (pid=%d) for user %d: '%s'\n",
+                            "Starting command job %d (pid: %d) for user %d: '%s'\n",
                             running_job->job.job_uuid,
                             running_job->job.cmd.pid,
                             running_job->job.uid,
@@ -180,7 +180,7 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
                             running_job->job.timeslot.secs;
                         break;
                     default:
-                        RESMAND_ERROR("Got malformed job type: %d.\n",
+                        RESMAND_ERROR("Received invalid job type: %d\n",
                                       running_job->job.job_type);
                 }
             }
@@ -226,7 +226,7 @@ int send_queue_info(int soc_client, unsigned int count) { /* {{{ */
     pthread_mutex_unlock(&mut_rj);
 
     if (send(soc_client, ser_buf, buf_len, 0) < 0) {
-        RESMAND_ERROR("Failed sending queue response to client.\n");
+        RESMAND_ERROR("Failed sending queue response to client\n");
         free(ser_buf);
         return -1;
     }
@@ -240,7 +240,7 @@ fail:
 } /* }}} */
 
 void sigint_handler(int sig UNUSED) { /*{{{*/
-    printf("Caught SIGINT: exiting.\n");
+    printf("Caught SIGINT, exiting\n");
     exit(EXIT_SUCCESS);
 } /*}}}*/
 

--- a/server/server.c
+++ b/server/server.c
@@ -33,6 +33,7 @@ int main(void) { /*{{{*/
         " |  _ <  __/\\__ \\ | | | | | (_| | | | |\n"
         " |_| \\_\\___||___/_| |_| |_|\\__,_|_| |_|\n"
         "Version 0.0\n");
+    fflush(stdout);
 
     disp_status();
     int soc_listen, soc_client;

--- a/server/server.c
+++ b/server/server.c
@@ -51,7 +51,7 @@ int main(void) { /*{{{*/
     }
 
     if (pthread_create(&thr_dispatcher, NULL, &dispatcher, NULL) != 0) {
-        fprintf(stderr, "pthread_create failed!.\n");
+        fprintf(stderr, "pthread_create failed!\n");
         return EXIT_FAILURE;
     }
 

--- a/server/server.c
+++ b/server/server.c
@@ -3,9 +3,7 @@
 
 #include <assert.h>
 #include <errno.h>
-#include <pwd.h>
 #include <signal.h>
-#include <stdbool.h>
 #include <stdlib.h>
 #include <sys/socket.h>
 #include <sys/un.h>

--- a/server/server.c
+++ b/server/server.c
@@ -93,7 +93,8 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
             switch (running_job->job.job_type) {
                 case JOB_TIMESLOT: {
                     if (running_job->manually_released || time(NULL) >= running_job->job.timeslot.t_end) {
-                        RESMAND_INFO("Job finished timeslot.\n");
+                        RESMAND_INFO("Timeslot job %d finished.\n",
+                                     running_job->job.job_uuid);
 
                         pthread_mutex_lock(&mut_rj);
                         free_queued_job(running_job);
@@ -122,7 +123,7 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
                         continue;
                     } else if (errno == ESRCH) {
                         /* The job has ended */
-                        RESMAND_INFO("Job finished, uuid=%d\n",
+                        RESMAND_INFO("Command job %d finished\n",
                                      running_job->job.job_uuid);
                         disp_status();
 
@@ -158,10 +159,11 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
                 switch (running_job->job.job_type) {
                     case JOB_CMD:
                         RESMAND_INFO(
-                            "Sending start signal to job(pid=%d, "
-                            "job_uuid=%d).\n",
+                            "Starting command job %d (pid=%d) for user %d: '%s'\n",
+                            running_job->job.job_uuid,
                             running_job->job.cmd.pid,
-                            running_job->job.job_uuid);
+                            running_job->job.uid,
+                            running_job->job.msg);
                         /* Tell the waiting job stub to start the desired
                          * process */
                         running_job->job.t_started = time(NULL);
@@ -169,8 +171,8 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
                         break;
                     case JOB_TIMESLOT:
                         RESMAND_INFO(
-                            "Serving time slot request. Sleeping for %d "
-                            "secs.\n",
+                            "Starting timeslot job %d. Sleeping for %ds\n",
+                            running_job->job.job_uuid,
                             running_job->job.timeslot.secs);
                         running_job->job.t_started = time(NULL);
                         running_job->job.timeslot.t_end =

--- a/testclient.sh
+++ b/testclient.sh
@@ -1,3 +1,23 @@
 #!/usr/bin/env bash
 
-./build/resman run -m "Hello!" -- bash -c 'echo Work: ; for i in {1..20} ; do echo -n $i, ; sleep 2 ; done'
+echo "Submitting 1 (time), while server idle --> should run right away"
+./build/resman time 1 -m "First (time)"
+sleep 1
+
+echo "Submitting 2 (command), while server idle --> should run right away"
+./build/resman run -m "Second (command)" -- bash -c 'echo Work: ; for i in {1..5} ; do echo -n $i, ; sleep 1 ; done'
+echo ""
+# Wait until server has detected job 2 completion
+sleep 1
+
+echo "Submitting 3 (time), while server idle --> should run right away"
+./build/resman time 3 -m "Third (time)"
+
+echo "Submitting 4 (command), while server busy --> should go into queue and run eventually"
+./build/resman run -m "Fourth (command)" -- bash -c 'echo Work: ; for i in {1..5} ; do echo -n $i, ; sleep 1 ; done'
+echo ""
+
+echo "Submitting 5 (time), but server busy --> should return an error message saying as much"
+./build/resman time 1 -m "Fifth (time, but server is busy)"
+
+echo ""


### PR DESCRIPTION
A bunch of things to improve usability a little bit here and there

- Some minor cleanups in the source code, but should probably just run clang-tidy over it at some point
- Fix resman header not appearing in system journal until some job starts (just flush stdout after printing it)
- Improve server log messages to improve observability
- Separate targets for client and server in Makefile
- Improve dequeue and release functions:
  - Allow dequeueing other users jobs with --force
  - More detailed server log messages for these operations
  - Add more specific status codes so client can emit more detailed messages
- Potentially fix a locking deadlock

Probably easiest to just look at each commit 1-by-1, tried to keep them fairly small and self-contained.