### PR TITLE
Log job duration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,10 @@ CLIENT_EXE=resman
 INSTALL_ROOT=/usr/local
 
 .PHONY: all
-all: $(BUILD)/resmand $(BUILD)/resman
+
+server: $(BUILD)/$(SERVER_EXE)
+client: $(BUILD)/$(CLIENT_EXE)
+all: server client
 
 $(BUILD)/$(SERVER_EXE): $(OBJS_SERVER)
 	@mkdir -p $(dir $@)

--- a/client/arg.c
+++ b/client/arg.c
@@ -160,6 +160,9 @@ error_t parser_dequeue(int key, char *arg, struct argp_state *state) { /*{{{*/
             printf("[info] Verbose mode enabled.\n");
             args->verbose = 1;
             break;
+        case 'f':
+            args->force = 1;
+            break;
         case ARGP_KEY_ARG:
             if (state->arg_num == 0) {
                 errno = 0;

--- a/client/arg.c
+++ b/client/arg.c
@@ -7,19 +7,20 @@
 
 void print_subcmds(char *prog) { /*{{{*/
     fprintf(stderr, "Usage: %s SUBCOMMAND [OPTION...]\n", prog);
-    fprintf(stderr, "Valid subcommands: [r]un, [t]ime, [c]heck, [d]equeue, [R]elease\n");
+    fprintf(
+        stderr,
+        "Valid subcommands: [r]un, [t]ime, [c]heck, [d]equeue, [R]elease\n");
 } /*}}}*/
 
 static unsigned int parse_duration(const char *s) { /*{{{*/
     unsigned int secs = 0;
-    unsigned long acc;
     char *endptr;
     const char *s_end = s + strlen(s);
 
     /* Up to three stages, one for each unit (h,m,s) */
     for (int stage = 0; stage < 3; stage++) {
         errno = 0;
-        acc = strtoul(s, &endptr, 10);
+        const unsigned long acc = strtoul(s, &endptr, 10);
 
         if (errno != 0) {
             /* Failed to parse */
@@ -56,7 +57,7 @@ static unsigned int parse_duration(const char *s) { /*{{{*/
     return secs;
 } /*}}}*/
 
-error_t parser_run(int key, char *arg, struct argp_state *state) { /*{{{*/
+error_t parser_run(const int key, char *arg, struct argp_state *state) { /*{{{*/
     struct args_run *args = (struct args_run *)state->input;
 
     switch (key) {
@@ -88,7 +89,8 @@ error_t parser_run(int key, char *arg, struct argp_state *state) { /*{{{*/
     return 0;
 } /*}}}*/
 
-error_t parser_time(int key, char *arg, struct argp_state *state) { /*{{{*/
+error_t parser_time(const int key, char *arg,
+                    struct argp_state *state) { /*{{{*/
     struct args_time *args = (struct args_time *)state->input;
 
     switch (key) {
@@ -101,8 +103,8 @@ error_t parser_time(int key, char *arg, struct argp_state *state) { /*{{{*/
             break;
         case ARGP_KEY_ARG:
             if (state->arg_num == 0) {
-                int dur = parse_duration(arg);
-                if (dur == -1) {
+                const unsigned int dur = parse_duration(arg);
+                if (dur == UINT_MAX) {
                     argp_error(state, "Invalid duration format: '%s'n", arg);
                 }
                 args->seconds = dur;
@@ -123,7 +125,8 @@ error_t parser_time(int key, char *arg, struct argp_state *state) { /*{{{*/
     return 0;
 } /*}}}*/
 
-error_t parser_check(int key, char *arg, struct argp_state *state) { /*{{{*/
+error_t parser_check(const int key, char *arg,
+                     struct argp_state *state) { /*{{{*/
     struct args_check *args = (struct args_check *)state->input;
     char *end;
 
@@ -137,10 +140,11 @@ error_t parser_check(int key, char *arg, struct argp_state *state) { /*{{{*/
             break;
         case 'n':
             errno = 0;
-            args->n = strtol(arg, &end, 10);
-            if (errno == ERANGE || end == arg) {
+            const long v = strtol(arg, &end, 10);
+            if (errno == ERANGE || end == arg || v < INT_MIN || v > INT_MAX) {
                 argp_error(state, "Invalid count: '%s'", arg);
             }
+            args->n = (int)v;
             break;
         case ARGP_KEY_ARG:
         case ARGP_KEY_END:
@@ -151,7 +155,8 @@ error_t parser_check(int key, char *arg, struct argp_state *state) { /*{{{*/
     return 0;
 } /*}}}*/
 
-error_t parser_dequeue(int key, char *arg, struct argp_state *state) { /*{{{*/
+error_t parser_dequeue(const int key, char *arg,
+                       struct argp_state *state) { /*{{{*/
     struct args_dequeue *args = (struct args_dequeue *)state->input;
     char *end;
 
@@ -166,10 +171,11 @@ error_t parser_dequeue(int key, char *arg, struct argp_state *state) { /*{{{*/
         case ARGP_KEY_ARG:
             if (state->arg_num == 0) {
                 errno = 0;
-                args->job_id = strtoul(arg, &end, 10);
-                if (errno == ERANGE || end == arg) {
-                    argp_error(state, "Invalid job id format: '%s'", arg);
+                const unsigned long v = strtoul(arg, &end, 10);
+                if (errno == ERANGE || end == arg || v > UINT_MAX) {
+                    argp_error(state, "Invalid count: '%s'", arg);
                 }
+                args->job_id = (int)v;
             } else {
                 argp_usage(state);
             }
@@ -186,8 +192,8 @@ error_t parser_dequeue(int key, char *arg, struct argp_state *state) { /*{{{*/
     return 0;
 } /*}}}*/
 
-error_t parser_release(int key, char *arg, struct argp_state *state) {// {{{
-    (void)arg; /* unused */
+error_t parser_release(const int key, char *arg UNUSED,
+                       struct argp_state *state) { /*{{{*/
     struct args_release *args = (struct args_release *)state->input;
 
     switch (key) {
@@ -204,4 +210,4 @@ error_t parser_release(int key, char *arg, struct argp_state *state) {// {{{
     }
 
     return 0;
-}// }}}
+} /*}}}*/

--- a/client/arg.c
+++ b/client/arg.c
@@ -28,6 +28,10 @@ static unsigned int parse_duration(const char *s) { /*{{{*/
             return -1;
         } else if (endptr == s_end) {
             /* Got to the end, so just return what we have */
+            if (stage == 0) {
+                // If no suffix is present at all, treat input as seconds
+                secs += acc;
+            }
             return secs;
         } else if (endptr == s) {
             /* Couldn't parse any further, due to invalid string */

--- a/client/client.c
+++ b/client/client.c
@@ -1,7 +1,6 @@
 // vim: fdm=marker
 #include "client.h"
 
-#include <argp.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/client/client.c
+++ b/client/client.c
@@ -41,7 +41,7 @@ int connect_to_server(const char *addr) { /*{{{*/
     struct sockaddr_un sa_server;
     unsigned int sa_len;
 
-    if ((soc = socket(AF_UNIX, SOCK_STREAM, 0)) < 0) {
+    if ((soc = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0)) < 0) {
         return -1;
     }
 

--- a/client/cmd.c
+++ b/client/cmd.c
@@ -400,7 +400,6 @@ int subcmd_dequeue(const int argc, char** argv) { /*{{{*/
     }
 
     req.req_type = IPCREQ_DEQUEUE;
-    req.deq.uid = getuid();
     req.deq.job_uuid = args.job_id;
     req.deq.force = args.force;
 

--- a/client/cmd.c
+++ b/client/cmd.c
@@ -447,11 +447,16 @@ int subcmd_release(int argc, char** argv) {// {{{
         return -1;
     }
 
-    if (stat.status == STATUS_OK) {
-        printf("Successfully released lock\n");
-    } else {
-        fprintf(stderr, "[error] Release failed (code %d)\n", stat.status);
-        return -1;
+    switch (stat.status) {
+        case STATUS_OK:
+            printf("Successfully released lock\n");
+            break;
+        case STATUS_REL_OK_SERVER_IDLE:
+            printf("Server is not currently locked, no lock to release.\n");
+            break;
+        default:
+            fprintf(stderr, "[error] Release failed (code %d)\n", stat.status);
+            return -1;
     }
 
     return 0;

--- a/client/cmd.c
+++ b/client/cmd.c
@@ -421,6 +421,7 @@ int subcmd_release(int argc, char** argv) {// {{{
     }
 
     req.req_type = IPCREQ_RELEASE;
+    req.rel.uid = getuid();
     req.rel.force = args.force;
 
     if ((soc = connect_to_server(socket_addr)) < 0) {

--- a/client/cmd.c
+++ b/client/cmd.c
@@ -10,7 +10,7 @@
 #include "client.h"
 #include "resman.h"
 
-const char *jobtype_lbl[] = {
+const char* jobtype_lbl[] = {
     "Command",
     "Time",
 };
@@ -32,16 +32,21 @@ static struct argp_option options_time[] = {
 };
 
 static struct argp argp_time = {
-    options_time, &parser_time,
-    "DURATION",   "Reserves the server for the given amount of time, specified using suffixes 's', 'm', or 'h' to specify seconds, minutes, or hours. These can be combined (e.g. 3h10m5s).",
-    NULL,         NULL,
+    options_time,
+    &parser_time,
+    "DURATION",
+    "Reserves the server for the given amount of time, specified using "
+    "suffixes 's', 'm', or 'h' to specify seconds, minutes, or hours. These "
+    "can be combined (e.g. 3h10m5s).",
+    NULL,
+    NULL,
     NULL};
 
 static struct argp_option options_check[] = {
-    {"silent",  's', 0, 0, "Don't print anything, just return status value.", 0},
-    {"count",   'n', "COUNT", 0, "How many queued jobs to view.", 0},
-    {"verbose", 'V', 0, 0, "Give verbose output.",          0},
-    {0,         0,   0, 0, 0,                               0},
+    {"silent",  's', 0,       0, "Don't print anything, just return status value.", 0},
+    {"count",   'n', "COUNT", 0, "How many queued jobs to view.",                   0},
+    {"verbose", 'V', 0,       0, "Give verbose output.",                            0},
+    {0,         0,   0,       0, 0,                                                 0},
 };
 
 static struct argp argp_check = {
@@ -50,36 +55,46 @@ static struct argp argp_check = {
 };
 
 static struct argp_option options_dequeue[] = {
-    {"force", 'f', 0, 0, "Even if target job belongs to different user.", 0},
-    {"verbose", 'V', 0, 0, "Give verbose output.", 0},
-    {0,         0,   0, 0, 0,                      0},
+    {"force",   'f', 0, 0, "Even if target job belongs to different user.", 0},
+    {"verbose", 'V', 0, 0, "Give verbose output.",                          0},
+    {0,         0,   0, 0, 0,                                               0},
 };
 
 static struct argp argp_dequeue = {
-    options_dequeue,    &parser_dequeue,    "JOB_ID",   "Dequeue a job.",
-    NULL,               NULL,               NULL,
+    options_dequeue,
+    &parser_dequeue,
+    "JOB_ID",
+    "Dequeue a job.",
+    NULL,
+    NULL,
+    NULL,
 };
 
 static struct argp_option options_release[] = {
-    {"force", 'f', 0, 0, "Even if current job belongs to different user.", 0},
-    {"verbose", 'V', 0, 0, "Give verbose output.", 0},
-    {0, 0, 0, 0, 0, 0},
+    {"force",   'f', 0, 0, "Even if current job belongs to different user.", 0},
+    {"verbose", 'V', 0, 0, "Give verbose output.",                           0},
+    {0,         0,   0, 0, 0,                                                0},
 };
 
 static struct argp argp_release = {
-    options_release,    &parser_release,    NULL,   "Release current job's lock. Does not terminate job.",
-    NULL,               NULL,               NULL,
+    options_release,
+    &parser_release,
+    NULL,
+    "Release current job's lock. Does not terminate job.",
+    NULL,
+    NULL,
+    NULL,
 };
 
-static int send_ipc_request(int soc, const ipc_request* req) { /*{{{*/
+static ssize_t send_ipc_request(const int soc, const ipc_request* req) { /*{{{*/
     if (!req) {
-        fprintf(stderr, "[bug]");
+        fprintf(stderr, "[bug] send_ipc_request received nullptr");
         return -1;
     }
     return send(soc, req, sizeof(ipc_request), 0);
 } /*}}}*/
 
-static int get_status(int soc, status_response* stat) { /*{{{*/
+static int get_status(const int soc, status_response* stat) { /*{{{*/
     if (!stat) return -1;
     if (recv(soc, stat, sizeof(status_response), 0) < 0) {
         return -1;
@@ -87,7 +102,7 @@ static int get_status(int soc, status_response* stat) { /*{{{*/
     return 0;
 } /*}}}*/
 
-int subcmd_run(int argc, char** argv) { /*{{{*/
+int subcmd_run(const int argc, char** argv) { /*{{{*/
     struct args_run args = {NULL, NULL, 0, 0};
 
     int soc;
@@ -199,7 +214,7 @@ int subcmd_run(int argc, char** argv) { /*{{{*/
     return -1;
 } /*}}}*/
 
-int subcmd_time(int argc, char** argv) { /*{{{*/
+int subcmd_time(const int argc, char** argv) { /*{{{*/
     struct args_time args = {NULL, -1, 0};
     job_descriptor job = {0};
     ipc_request req;
@@ -271,7 +286,7 @@ int subcmd_check(int argc UNUSED, char** argv UNUSED) { /*{{{*/
     unsigned int resp_maxlen;
     int soc;
 
-    int ret = argp_parse(&argp_check, argc - 1, argv + 1, 0, 0, (void*)&args);
+    const int ret = argp_parse(&argp_check, argc - 1, argv + 1, 0, 0, &args);
     if (ret != 0) {
         exit(-1);
     }
@@ -305,6 +320,7 @@ int subcmd_check(int argc UNUSED, char** argv UNUSED) { /*{{{*/
 
     if (recv(soc, resp_buf, resp_maxlen, 0) < 0) {
         perror("recv");
+        free(resp_buf);
         return -1;
     }
 
@@ -342,7 +358,7 @@ int subcmd_check(int argc UNUSED, char** argv UNUSED) { /*{{{*/
             char time_buf[32];
 
             for (int i = 0; i < (int)resp_header->resp_count; i++) {
-                struct passwd* pwd = getpwuid(jobs[i].uid);
+                const struct passwd* pwd = getpwuid(jobs[i].uid);
                 strftime(time_buf, sizeof(time_buf), "%a %e %b %T",
                          localtime(&jobs[i].t_submitted));
 
@@ -359,26 +375,29 @@ int subcmd_check(int argc UNUSED, char** argv UNUSED) { /*{{{*/
         }
     }
 
-    return resp_header->currently_running;
+    const int running = resp_header->currently_running;
+    free(resp_buf);
+    return running;
 } /*}}}*/
 
-int subcmd_dequeue(int argc, char** argv) { /*{{{*/
+int subcmd_dequeue(const int argc, char** argv) { /*{{{*/
     struct args_dequeue args = {.job_id = -1, .force = 0, .verbose = 0};
     ipc_request req;
     status_response stat;
     int soc;
 
-    int ret = argp_parse(&argp_dequeue, argc - 1, argv + 1, 0, 0, (void*)&args);
+    const int ret =
+        argp_parse(&argp_dequeue, argc - 1, argv + 1, 0, 0, (void*)&args);
     if (ret != 0) {
         if (ret == EINVAL) {
-            fprintf(stderr, "Invalid job ID.\n");
+            fprintf(stderr, "Invalid job ID\n");
             exit(EINVAL);
         }
         exit(-1);
     }
 
     if (args.job_id > UUID_MAX || args.job_id < 0) {
-        fprintf(stderr, "Invalid job ID.\n");
+        fprintf(stderr, "Invalid job ID\n");
         return -1;
     }
 
@@ -407,13 +426,21 @@ int subcmd_dequeue(int argc, char** argv) { /*{{{*/
             printf("Successfully dequeued job %d\n", args.job_id);
             break;
         case STATUS_DEQ_FAIL_JOB_CURRENTLY_RUNNING:
-            fprintf(stderr, "[error] Cannot dequeue currently running job. Consider releasing the lock instead.\n");
+            fprintf(stderr,
+                    "[error] Cannot dequeue currently running job. Consider "
+                    "releasing the lock instead.\n");
             break;
         case STATUS_DEQ_FAIL_NO_SUCH_JOB:
-            fprintf(stderr, "[error] Failed to dequeue job %d: job not found in queue\n", args.job_id);
+            fprintf(
+                stderr,
+                "[error] Failed to dequeue job %d: job not found in queue\n",
+                args.job_id);
             break;
         case STATUS_DEQ_FAIL_NOT_YOUR_JOB:
-            fprintf(stderr, "[error] Failed to dequeue job %d submitted by another user\n", args.job_id);
+            fprintf(
+                stderr,
+                "[error] Failed to dequeue job %d submitted by another user\n",
+                args.job_id);
             break;
         default:
             fprintf(stderr, "[error] Dequeue failed (code: %d)\n", stat.status);
@@ -423,13 +450,14 @@ int subcmd_dequeue(int argc, char** argv) { /*{{{*/
     return 0;
 } /*}}}*/
 
-int subcmd_release(int argc, char** argv) {// {{{
+int subcmd_release(const int argc, char** argv) {  // {{{
     struct args_release args = {.force = 0, .verbose = 0};
     ipc_request req;
     status_response stat;
     int soc;
 
-    int ret = argp_parse(&argp_release, argc - 1, argv + 1, 0, 0, (void*)&args);
+    const int ret =
+        argp_parse(&argp_release, argc - 1, argv + 1, 0, 0, (void*)&args);
     if (ret != 0) {
         exit(-1);
     }
@@ -461,7 +489,9 @@ int subcmd_release(int argc, char** argv) {// {{{
             printf("Server is not currently locked, no lock to release.\n");
             break;
         case STATUS_REL_FAIL_NOT_YOUR_JOB:
-            fprintf(stderr, "[error] Refusing to release lock held by another user, consider using --force.\n");
+            fprintf(stderr,
+                    "[error] Refusing to release lock held by another user, "
+                    "consider using --force.\n");
             break;
         default:
             fprintf(stderr, "[error] Release failed (code %d)\n", stat.status);
@@ -469,4 +499,4 @@ int subcmd_release(int argc, char** argv) {// {{{
     }
 
     return 0;
-}// }}}
+}  // }}}

--- a/client/cmd.c
+++ b/client/cmd.c
@@ -161,21 +161,6 @@ int subcmd_run(const int argc, char** argv) { /*{{{*/
         return -1;
     }
 
-    if (send_ipc_request(soc, &req) < 0) {
-        perror("[error] Failed send()'ing request.\n");
-        return -1;
-    }
-
-    if (get_status(soc, &resp) < 0) {
-        perror("get_status");
-        return -1;
-    }
-
-    if (resp.status != STATUS_OK) {
-        fprintf(stderr, "Failed to enqueue job.\n");
-        return -1;
-    }
-
     if (sigemptyset(&sigset) < 0) {
         perror("sigemptyset");
         return -1;
@@ -188,6 +173,21 @@ int subcmd_run(const int argc, char** argv) { /*{{{*/
 
     if (sigprocmask(SIG_BLOCK, &sigset, NULL) < 0) {
         perror("sigprocmask");
+        return -1;
+    }
+
+    if (send_ipc_request(soc, &req) < 0) {
+        perror("[error] Failed send()'ing request.\n");
+        return -1;
+    }
+
+    if (get_status(soc, &resp) < 0) {
+        perror("get_status");
+        return -1;
+    }
+
+    if (resp.status != STATUS_OK) {
+        fprintf(stderr, "Failed to enqueue job.\n");
         return -1;
     }
 

--- a/client/cmd.c
+++ b/client/cmd.c
@@ -37,7 +37,8 @@ static struct argp argp_time = {
     "DURATION",
     "Reserves the server for the given amount of time, specified using "
     "suffixes 's', 'm', or 'h' to specify seconds, minutes, or hours. These "
-    "can be combined (e.g. 3h10m5s).",
+    "can be combined (e.g. 3h10m5s). A number without suffix is treated as "
+    "seconds (e.g. a duration of 120 will reserve the server for two minutes).",
     NULL,
     NULL,
     NULL};

--- a/client/cmd.c
+++ b/client/cmd.c
@@ -460,7 +460,6 @@ int subcmd_release(const int argc, char** argv) {  // {{{
     }
 
     req.req_type = IPCREQ_RELEASE;
-    req.rel.uid = getuid();
     req.rel.force = args.force;
 
     if ((soc = connect_to_server(socket_addr)) < 0) {

--- a/client/cmd.c
+++ b/client/cmd.c
@@ -50,6 +50,7 @@ static struct argp argp_check = {
 };
 
 static struct argp_option options_dequeue[] = {
+    {"force", 'f', 0, 0, "Even if target job belongs to different user.", 0},
     {"verbose", 'V', 0, 0, "Give verbose output.", 0},
     {0,         0,   0, 0, 0,                      0},
 };
@@ -362,7 +363,7 @@ int subcmd_check(int argc UNUSED, char** argv UNUSED) { /*{{{*/
 } /*}}}*/
 
 int subcmd_dequeue(int argc, char** argv) { /*{{{*/
-    struct args_dequeue args = {.job_id = -1, .verbose = 0};
+    struct args_dequeue args = {.job_id = -1, .force = 0, .verbose = 0};
     ipc_request req;
     status_response stat;
     int soc;
@@ -384,6 +385,7 @@ int subcmd_dequeue(int argc, char** argv) { /*{{{*/
     req.req_type = IPCREQ_DEQUEUE;
     req.deq.uid = getuid();
     req.deq.job_uuid = args.job_id;
+    req.deq.force = args.force;
 
     if ((soc = connect_to_server(socket_addr)) < 0) {
         fprintf(stderr, "[error] Failed to connect to daemon.\n");

--- a/client/cmd.c
+++ b/client/cmd.c
@@ -143,9 +143,7 @@ int subcmd_run(const int argc, char** argv) { /*{{{*/
             JOB_MSG_LEN);
     }
 
-    job.uid = getuid();
     job.t_submitted = time(NULL);
-    job.cmd.pid = getpid();
     job.job_type = JOB_CMD;
 
     if (args.msg) {
@@ -239,7 +237,6 @@ int subcmd_time(const int argc, char** argv) { /*{{{*/
         }
     }
 
-    job.uid = getuid();
     job.t_submitted = time(NULL);
     job.job_type = JOB_TIMESLOT;
     job.timeslot.secs = args.seconds;

--- a/client/cmd.c
+++ b/client/cmd.c
@@ -253,8 +253,8 @@ int subcmd_time(int argc, char** argv) { /*{{{*/
 
     if (resp.status != STATUS_OK) {
         fprintf(stderr,
-                "Could not reserve time slot. Perhaps the server is already in "
-                "use?");
+                "[error] Could not reserve timeslot. Perhaps the server "
+                "is already in use?\n");
         return -1;
     }
 

--- a/client/cmd.c
+++ b/client/cmd.c
@@ -454,6 +454,9 @@ int subcmd_release(int argc, char** argv) {// {{{
         case STATUS_REL_OK_SERVER_IDLE:
             printf("Server is not currently locked, no lock to release.\n");
             break;
+        case STATUS_REL_FAIL_NOT_YOUR_JOB:
+            fprintf(stderr, "[error] Refusing to release lock held by another user, consider using --force.\n");
+            break;
         default:
             fprintf(stderr, "[error] Release failed (code %d)\n", stat.status);
             return -1;

--- a/client/cmd.c
+++ b/client/cmd.c
@@ -382,6 +382,7 @@ int subcmd_dequeue(int argc, char** argv) { /*{{{*/
     }
 
     req.req_type = IPCREQ_DEQUEUE;
+    req.deq.uid = getuid();
     req.deq.job_uuid = args.job_id;
 
     if ((soc = connect_to_server(socket_addr)) < 0) {
@@ -408,6 +409,9 @@ int subcmd_dequeue(int argc, char** argv) { /*{{{*/
             break;
         case STATUS_DEQ_FAIL_NO_SUCH_JOB:
             fprintf(stderr, "[error] Failed to dequeue job %d: job not found in queue\n", args.job_id);
+            break;
+        case STATUS_DEQ_FAIL_NOT_YOUR_JOB:
+            fprintf(stderr, "[error] Failed to dequeue job %d submitted by another user\n", args.job_id);
             break;
         default:
             fprintf(stderr, "[error] Dequeue failed (code: %d)\n", stat.status);

--- a/client/cmd.c
+++ b/client/cmd.c
@@ -33,7 +33,7 @@ static struct argp_option options_time[] = {
 
 static struct argp argp_time = {
     options_time, &parser_time,
-    "DURATION",   "Reserves the server for some time.",
+    "DURATION",   "Reserves the server for the given amount of time, specified using suffixes 's', 'm', or 'h' to specify seconds, minutes, or hours. These can be combined (e.g. 3h10m5s).",
     NULL,         NULL,
     NULL};
 

--- a/client/cmd.c
+++ b/client/cmd.c
@@ -424,7 +424,7 @@ int subcmd_release(int argc, char** argv) {// {{{
     req.rel.force = args.force;
 
     if ((soc = connect_to_server(socket_addr)) < 0) {
-        fprintf(stderr, "[error] Failed to connect to daemon.\n");
+        fprintf(stderr, "[error] Failed to connect to daemon\n");
         return -1;
     }
 
@@ -439,9 +439,9 @@ int subcmd_release(int argc, char** argv) {// {{{
     }
 
     if (stat.status == STATUS_OK) {
-        printf("Succesfully released lock.\n");
+        printf("Successfully released lock\n");
     } else {
-        printf("Release failed. Status = %d\n", stat.status);
+        fprintf(stderr, "[error] Release failed (code %d)\n", stat.status);
         return -1;
     }
 

--- a/client/cmd.c
+++ b/client/cmd.c
@@ -208,14 +208,13 @@ int subcmd_time(int argc, char** argv) { /*{{{*/
 
     argp_parse(&argp_time, argc - 1, argv + 1, 0, 0, (void*)&args);
 
-    if (args.verbose) {
-        if (args.seconds <= 0) {
-            fprintf(stderr, "No duration was given.\n");
-            return -1;
-        } else {
-            printf("Duration: %d seconds\n", args.seconds);
-        }
+    if (args.seconds <= 0) {
+        fprintf(stderr, "[error] Invalid duration, must be > 0 seconds.\n");
+        return -1;
+    }
 
+    if (args.verbose) {
+        printf("Duration: %d seconds\n", args.seconds);
         if (args.msg) {
             printf("Message: %s\n", args.msg);
         } else {

--- a/client/cmd.c
+++ b/client/cmd.c
@@ -382,7 +382,7 @@ int subcmd_dequeue(int argc, char** argv) { /*{{{*/
     }
 
     req.req_type = IPCREQ_DEQUEUE;
-    req.deq.job_uuid = (uuid_t)args.job_id;
+    req.deq.job_uuid = args.job_id;
 
     if ((soc = connect_to_server(socket_addr)) < 0) {
         fprintf(stderr, "[error] Failed to connect to daemon.\n");
@@ -399,11 +399,19 @@ int subcmd_dequeue(int argc, char** argv) { /*{{{*/
         return -1;
     }
 
-    if (stat.status == STATUS_OK) {
-        printf("Succesfully dequeued job %d\n", args.job_id);
-    } else {
-        printf("Dequeue failed. Status = %d\n", stat.status);
-        return -1;
+    switch (stat.status) {
+        case STATUS_OK:
+            printf("Successfully dequeued job %d\n", args.job_id);
+            break;
+        case STATUS_DEQ_FAIL_JOB_CURRENTLY_RUNNING:
+            fprintf(stderr, "[error] Cannot dequeue currently running job. Consider releasing the lock instead.\n");
+            break;
+        case STATUS_DEQ_FAIL_NO_SUCH_JOB:
+            fprintf(stderr, "[error] Failed to dequeue job %d: job not found in queue\n", args.job_id);
+            break;
+        default:
+            fprintf(stderr, "[error] Dequeue failed (code: %d)\n", stat.status);
+            return -1;
     }
 
     return 0;

--- a/common/common.c
+++ b/common/common.c
@@ -1,5 +1,3 @@
-#include "resman.h"
-
 /* This socket address is actually used as an abstract socket address.
  * This means that when it's passed to `bind`, etc., it's prefixed with a NULL
  * byte, and then doesn't have a filesystem representation at all. */

--- a/include/client.h
+++ b/include/client.h
@@ -45,6 +45,7 @@ struct args_check {
 
 struct args_dequeue {
     uuid_t job_id;
+    int force;
     int verbose;
 };
 

--- a/include/client.h
+++ b/include/client.h
@@ -1,7 +1,9 @@
 // vim: fdm=marker
 #ifndef CLIENT_H
 #define CLIENT_H
+
 #include <argp.h>
+
 #include "resman.h"
 
 #define CLIENT_VER_STRING "0.0"

--- a/include/resman.h
+++ b/include/resman.h
@@ -58,6 +58,7 @@ typedef struct info_request {
 } info_request;
 
 typedef struct dequeue_request {
+    uid_t uid;
     uuid_t job_uuid;
 } dequeue_request;
 
@@ -79,6 +80,7 @@ typedef struct status_response {
         // Dequeue request failure types
         STATUS_DEQ_FAIL_JOB_CURRENTLY_RUNNING,
         STATUS_DEQ_FAIL_NO_SUCH_JOB,
+        STATUS_DEQ_FAIL_NOT_YOUR_JOB,
         // Release request status types
         STATUS_REL_OK_SERVER_IDLE,
         STATUS_REL_FAIL_NOT_YOUR_JOB,

--- a/include/resman.h
+++ b/include/resman.h
@@ -62,6 +62,7 @@ typedef struct dequeue_request {
 } dequeue_request;
 
 typedef struct release_request {
+    uid_t uid;
     int force;
 } release_request;
 

--- a/include/resman.h
+++ b/include/resman.h
@@ -44,7 +44,7 @@ typedef struct job_descriptor {
     enum job_type job_type;
     union {
         struct {
-            pid_t pid;  // Job stub PID
+            int pidfd;  // PIDFD for the job process
         } cmd;
         struct {
             unsigned int secs;  // Seconds to reserve

--- a/include/resman.h
+++ b/include/resman.h
@@ -76,6 +76,9 @@ typedef struct status_response {
     enum {
         STATUS_OK,
         STATUS_FAIL,
+        // Dequeue request failure types
+        STATUS_DEQ_FAIL_JOB_CURRENTLY_RUNNING,
+        STATUS_DEQ_FAIL_NO_SUCH_JOB,
     } status;
 } status_response;
 

--- a/include/resman.h
+++ b/include/resman.h
@@ -58,7 +58,6 @@ typedef struct info_request {
 } info_request;
 
 typedef struct dequeue_request {
-    uid_t uid;
     uuid_t job_uuid;
     int force;
 } dequeue_request;

--- a/include/resman.h
+++ b/include/resman.h
@@ -81,6 +81,7 @@ typedef struct status_response {
         STATUS_DEQ_FAIL_NO_SUCH_JOB,
         // Release request status types
         STATUS_REL_OK_SERVER_IDLE,
+        STATUS_REL_FAIL_NOT_YOUR_JOB,
     } status;
 } status_response;
 

--- a/include/resman.h
+++ b/include/resman.h
@@ -60,6 +60,7 @@ typedef struct info_request {
 typedef struct dequeue_request {
     uid_t uid;
     uuid_t job_uuid;
+    int force;
 } dequeue_request;
 
 typedef struct release_request {

--- a/include/resman.h
+++ b/include/resman.h
@@ -64,7 +64,6 @@ typedef struct dequeue_request {
 } dequeue_request;
 
 typedef struct release_request {
-    uid_t uid;
     int force;
 } release_request;
 

--- a/include/resman.h
+++ b/include/resman.h
@@ -79,6 +79,8 @@ typedef struct status_response {
         // Dequeue request failure types
         STATUS_DEQ_FAIL_JOB_CURRENTLY_RUNNING,
         STATUS_DEQ_FAIL_NO_SUCH_JOB,
+        // Release request status types
+        STATUS_REL_OK_SERVER_IDLE,
     } status;
 } status_response;
 

--- a/include/server.h
+++ b/include/server.h
@@ -16,8 +16,6 @@
 typedef struct queued_job {
     job_descriptor job;
     struct queued_job *next;
-    time_t t_started;
-    time_t t_ended;
     int manually_released;
 } queued_job;
 

--- a/include/server.h
+++ b/include/server.h
@@ -9,8 +9,8 @@
 #define LISTEN_QUEUE 8
 #define POLL_DELAY 2
 
-#define RESMAND_INFO(...) printf("[info]" __VA_ARGS__); fflush(stdout);
-#define RESMAND_ERROR(...) printf("[error!]" __VA_ARGS__); fflush(stdout);
+#define RESMAND_INFO(...) printf("[info] " __VA_ARGS__); fflush(stdout);
+#define RESMAND_ERROR(...) printf("[error!] " __VA_ARGS__); fflush(stdout);
 
 /* Thin wrapper around job descriptor for server-only fields */
 typedef struct queued_job {

--- a/include/server.h
+++ b/include/server.h
@@ -32,7 +32,7 @@ void *dispatcher(void *args);
 int make_soc_listen(const char *addr);
 int handle_client(int soc_client);
 void sigint_handler(int sig);
-const queued_job *peek_job(queued_job *q, int off);
+const queued_job *peek_job(const queued_job *q, int off);
 queued_job *deq_job(queued_job **q);
 int enq_job(queued_job **q, job_descriptor job);
 int queue_len(queued_job *q);

--- a/include/server.h
+++ b/include/server.h
@@ -36,6 +36,7 @@ const queued_job *peek_job(queued_job *q, int off);
 queued_job *deq_job(queued_job **q);
 int enq_job(queued_job **q, job_descriptor job);
 int queue_len(queued_job *q);
+queued_job *find_job(queued_job **q, uuid_t uuid);
 queued_job *remove_job(queued_job **q, uuid_t uuid);
 int send_queue_info(int soc_client, unsigned int count);
 void disp_status(void);

--- a/include/server.h
+++ b/include/server.h
@@ -1,6 +1,10 @@
 // vim: fdm=marker
-#include "resman.h"
+#ifndef SERVER_H
+#define SERVER_H
+
 #include <pthread.h> /* pthread_mutex_* */
+
+#include "resman.h"
 
 #define LISTEN_QUEUE 8
 #define POLL_DELAY 2
@@ -35,3 +39,5 @@ int queue_len(queued_job *q);
 queued_job *remove_job(queued_job **q, uuid_t uuid);
 int send_queue_info(int soc_client, unsigned int count);
 void disp_status(void);
+
+#endif  /* SERVER_H */

--- a/include/server.h
+++ b/include/server.h
@@ -39,6 +39,5 @@ int queue_len(queued_job *q);
 queued_job *find_job(queued_job **q, uuid_t uuid);
 queued_job *remove_job(queued_job **q, uuid_t uuid);
 int send_queue_info(int soc_client, unsigned int count);
-void disp_status(void);
 
 #endif  /* SERVER_H */

--- a/include/server.h
+++ b/include/server.h
@@ -10,7 +10,7 @@
 #define POLL_DELAY 2
 
 #define RESMAND_INFO(...) printf("[info] " __VA_ARGS__); fflush(stdout);
-#define RESMAND_ERROR(...) printf("[error!] " __VA_ARGS__); fflush(stdout);
+#define RESMAND_ERROR(...) printf("[error] " __VA_ARGS__); fflush(stdout);
 
 /* Thin wrapper around job descriptor for server-only fields */
 typedef struct queued_job {

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -74,106 +74,109 @@ int handle_client(int soc_client) { /*{{{*/
         return -1;
     }
 
-    if (req.req_type == IPCREQ_JOB) {
-        job_descriptor job = req.job;
+    switch (req.req_type) {
+        case IPCREQ_JOB:
+            job_descriptor job = req.job;
 
-        if (job.job_type != JOB_CMD && job.job_type != JOB_TIMESLOT) {
-            RESMAND_ERROR("Invalid job type in request\n");
-            goto _close;
-        }
+            if (job.job_type != JOB_CMD && job.job_type != JOB_TIMESLOT) {
+                RESMAND_ERROR("Invalid job type in request\n");
+                goto _close;
+            }
 
-        job.job_uuid = next_uuid();
+            job.job_uuid = next_uuid();
 
-        switch (job.job_type) {
-            case JOB_CMD:
-                RESMAND_INFO(
-                    "Received command job %d by user %d (pid: %d, msg: '%s')\n",
-                    job.job_uuid, job.uid, job.cmd.pid, job.msg
-                );
-                pthread_mutex_lock(&mut_q);
-                enq_job(&q, job);
-                pthread_mutex_unlock(&mut_q);
-                resp.status = STATUS_OK;
-                break;
-            case JOB_TIMESLOT:
-                RESMAND_INFO(
-                    "Received timeslot job %d by user %d (time: %ds, msg: '%s')\n",
-                    job.job_uuid, job.uid, job.timeslot.secs, job.msg
-                );
-
-                if (running_job || peek_job(q, 0)) {
+            switch (job.job_type) {
+                case JOB_CMD:
                     RESMAND_INFO(
-                        "Rejecting timeslot job %d: server is already reserved\n",
-                        job.job_uuid
+                        "Received command job %d by user %d (pid: %d, msg: '%s')\n",
+                        job.job_uuid, job.uid, job.cmd.pid, job.msg
                     );
-                    resp.status = STATUS_FAIL;
+                    pthread_mutex_lock(&mut_q);
+                    enq_job(&q, job);
+                    pthread_mutex_unlock(&mut_q);
+                    resp.status = STATUS_OK;
                     break;
-                }
+                case JOB_TIMESLOT:
+                    RESMAND_INFO(
+                        "Received timeslot job %d by user %d (time: %ds, msg: '%s')\n",
+                        job.job_uuid, job.uid, job.timeslot.secs, job.msg
+                    );
 
-                pthread_mutex_lock(&mut_q);
-                enq_job(&q, job);
-                pthread_mutex_unlock(&mut_q);
-                resp.status = STATUS_OK;
-                break;
-        }
+                    if (running_job || peek_job(q, 0)) {
+                        RESMAND_INFO(
+                            "Rejecting timeslot job %d: server is already reserved\n",
+                            job.job_uuid
+                        );
+                        resp.status = STATUS_FAIL;
+                        break;
+                    }
 
-        send_status(soc_client, &resp);
-        disp_status();
-    } else if (req.req_type == IPCREQ_VIEW_QUEUE) {
-        info_request info = req.info;
-        send_queue_info(soc_client, info.n_view);
-    } else if (req.req_type == IPCREQ_DEQUEUE) {
-        dequeue_request deq = req.deq;
-        RESMAND_INFO("Received dequeue request for job %d\n", deq.job_uuid);
+                    pthread_mutex_lock(&mut_q);
+                    enq_job(&q, job);
+                    pthread_mutex_unlock(&mut_q);
+                    resp.status = STATUS_OK;
+                    break;
+            }
 
-        pthread_mutex_lock(&mut_rj);
-        pthread_mutex_lock(&mut_q);
+            send_status(soc_client, &resp);
+            break;
+        case IPCREQ_VIEW_QUEUE:
+            info_request info = req.info;
+            send_queue_info(soc_client, info.n_view);
+            break;
+        case IPCREQ_DEQUEUE:
+            dequeue_request deq = req.deq;
+            RESMAND_INFO("Received dequeue request for job %d\n", deq.job_uuid);
 
-        if (running_job && running_job->job.job_uuid == deq.job_uuid) {
-            RESMAND_ERROR("Refusing to dequeue currently running job\n")
-            resp.status = STATUS_DEQ_FAIL_JOB_CURRENTLY_RUNNING;
-        } else {
-            queued_job *deq_job = remove_job(&q, deq.job_uuid);
-            if (!deq_job) {
-                RESMAND_ERROR("Failed to dequeue job %d: not found in queue"
-                              "\n", deq.job_uuid);
-                resp.status = STATUS_DEQ_FAIL_NO_SUCH_JOB;
+            pthread_mutex_lock(&mut_rj);
+            pthread_mutex_lock(&mut_q);
+
+            if (running_job && running_job->job.job_uuid == deq.job_uuid) {
+                RESMAND_ERROR("Refusing to dequeue currently running job\n")
+                resp.status = STATUS_DEQ_FAIL_JOB_CURRENTLY_RUNNING;
             } else {
-                RESMAND_INFO("Dequeueueueueing job %d\n", deq_job->job.job_uuid);
-                free_queued_job(deq_job);
+                queued_job *deq_job = remove_job(&q, deq.job_uuid);
+                if (!deq_job) {
+                    RESMAND_ERROR("Failed to dequeue job %d: not found in queue"
+                                  "\n", deq.job_uuid);
+                    resp.status = STATUS_DEQ_FAIL_NO_SUCH_JOB;
+                } else {
+                    RESMAND_INFO("Dequeueueueueing job %d\n", deq_job->job.job_uuid);
+                    free_queued_job(deq_job);
+                    resp.status = STATUS_OK;
+                }
+            }
+
+            pthread_mutex_unlock(&mut_q);
+            pthread_mutex_unlock(&mut_rj);
+
+            send_status(soc_client, &resp);
+            break;
+        case IPCREQ_RELEASE:
+            release_request rel = req.rel;
+
+            if (!running_job) {
+                RESMAND_INFO("Received manual release request by user %d, but "
+                             "server is not reserved. Nothing to do.\n",
+                             rel.uid)
+                resp.status = STATUS_OK;
+            } else {
+                RESMAND_INFO("Received manual release request by user %d (force: "
+                             "%d), cancelling current running job %d\n",
+                             rel.uid, rel.force, running_job->job.job_uuid);
+                pthread_mutex_lock(&mut_rj);
+                running_job->manually_released = 1;
+                pthread_mutex_unlock(&mut_rj);
                 resp.status = STATUS_OK;
             }
-        }
-
-        pthread_mutex_unlock(&mut_q);
-        pthread_mutex_unlock(&mut_rj);
-
-        send_status(soc_client, &resp);
-
-        disp_status();
-    } else if (req.req_type == IPCREQ_RELEASE) {
-        release_request rel = req.rel;
-
-        if (!running_job) {
-            RESMAND_INFO("Received manual release request by user %d, but "
-                         "server is not reserved. Nothing to do.\n",
-                         rel.uid)
-            resp.status = STATUS_OK;
-        } else {
-            RESMAND_INFO("Received manual release request by user %d (force: "
-                         "%d), cancelling current running job %d\n",
-                         rel.uid, rel.force, running_job->job.job_uuid);
-            pthread_mutex_lock(&mut_rj);
-            running_job->manually_released = 1;
-            pthread_mutex_unlock(&mut_rj);
-            resp.status = STATUS_OK;
-        }
-        send_status(soc_client, &resp);
-    } else {
-        RESMAND_ERROR("Invalid request type: %d\n", req.req_type);
-        close(soc_client);
-        return -1;
+            send_status(soc_client, &resp);
+            break;
+        default:
+            RESMAND_ERROR("Invalid request type: %d\n", req.req_type);
+            close(soc_client);
+            return -1;
     }
+
 _close:
     close(soc_client);
 

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -49,27 +49,28 @@ static uuid_t next_uuid(void) { /*{{{*/
     return ++next;
 } /*}}}*/
 
-static int send_status(int soc, status_response *resp) {/*{{{*/
+static ssize_t send_status(const int soc, status_response *resp) { /*{{{*/
     if (!resp) return -1;
     return send(soc, resp, sizeof(status_response), 0);
-}/*}}}*/
+} /*}}}*/
 
 /* Handle a new client connection. This will wait for the client to send a
  * request, at which point -- based on the type of request -- it will perform
  * the necessary action.
  * Returns -1 on failure, or 0 on success. */
-int handle_client(int soc_client) { /*{{{*/
+int handle_client(const int soc_client) { /*{{{*/
     ipc_request req;
     status_response resp;
 
-    int bytes_read;
+    ssize_t bytes_read;
     if ((bytes_read = recv(soc_client, &req, sizeof(req), 0)) == -1) {
         perror("recv");
     }
 
     if (bytes_read != sizeof(req)) {
-        RESMAND_ERROR("Problem with client request: got %d bytes but expected %lu\n",
-               bytes_read, sizeof(req));
+        RESMAND_ERROR(
+            "Problem with client request: got %ld bytes but expected %lu\n",
+            bytes_read, sizeof(req));
         close(soc_client);
         return -1;
     }
@@ -88,9 +89,9 @@ int handle_client(int soc_client) { /*{{{*/
             switch (job.job_type) {
                 case JOB_CMD:
                     RESMAND_INFO(
-                        "Received command job %d by user %d (pid: %d, msg: '%s')\n",
-                        job.job_uuid, job.uid, job.cmd.pid, job.msg
-                    );
+                        "Received command job %d by user %d (pid: %d, msg: "
+                        "'%s')\n",
+                        job.job_uuid, job.uid, job.cmd.pid, job.msg);
                     pthread_mutex_lock(&mut_q);
                     enq_job(&q, job);
                     pthread_mutex_unlock(&mut_q);
@@ -98,15 +99,15 @@ int handle_client(int soc_client) { /*{{{*/
                     break;
                 case JOB_TIMESLOT:
                     RESMAND_INFO(
-                        "Received timeslot job %d by user %d (time: %ds, msg: '%s')\n",
-                        job.job_uuid, job.uid, job.timeslot.secs, job.msg
-                    );
+                        "Received timeslot job %d by user %d (time: %ds, msg: "
+                        "'%s')\n",
+                        job.job_uuid, job.uid, job.timeslot.secs, job.msg);
 
                     if (running_job || peek_job(q, 0)) {
                         RESMAND_INFO(
-                            "Rejecting timeslot job %d: server is already reserved\n",
-                            job.job_uuid
-                        );
+                            "Rejecting timeslot job %d: server is already "
+                            "reserved\n",
+                            job.job_uuid);
                         resp.status = STATUS_FAIL;
                         break;
                     }
@@ -131,29 +132,31 @@ int handle_client(int soc_client) { /*{{{*/
             pthread_mutex_lock(&mut_rj);
 
             if (running_job && running_job->job.job_uuid == deq.job_uuid) {
-                RESMAND_ERROR("Received dequeue request by user %d for job %d, "
-                              "but refusing to dequeue currently running job\n",
-                              deq.uid, deq.job_uuid)
+                RESMAND_ERROR(
+                    "Received dequeue request by user %d for job %d, "
+                    "but refusing to dequeue currently running job\n",
+                    deq.uid, deq.job_uuid)
                 resp.status = STATUS_DEQ_FAIL_JOB_CURRENTLY_RUNNING;
             } else {
                 queued_job *target_job = find_job(&q, deq.job_uuid);
                 if (!target_job) {
-                    RESMAND_ERROR("Received dequeue request by user %d for job "
-                                  "%d, but no such job in queue\n",
-                                  deq.uid, deq.job_uuid);
+                    RESMAND_ERROR(
+                        "Received dequeue request by user %d for job "
+                        "%d, but no such job in queue\n",
+                        deq.uid, deq.job_uuid);
                     resp.status = STATUS_DEQ_FAIL_NO_SUCH_JOB;
                 } else if (target_job->job.uid != deq.uid && !deq.force) {
-                    RESMAND_ERROR("Received dequeue request by user %d for job "
-                                  "%d owned by %d (force: %d), refusing to "
-                                  "dequeue\n",
-                                  deq.uid, deq.job_uuid, target_job->job.uid,
-                                  deq.force);
+                    RESMAND_ERROR(
+                        "Received dequeue request by user %d for job "
+                        "%d owned by %d (force: %d), refusing to "
+                        "dequeue\n",
+                        deq.uid, deq.job_uuid, target_job->job.uid, deq.force);
                     resp.status = STATUS_DEQ_FAIL_NOT_YOUR_JOB;
                 } else {
-                    RESMAND_INFO("Received dequeue request by user %d for job "
-                                 "%d owned by %d (force: %d), dequeueing job\n",
-                                 deq.uid, deq.job_uuid, target_job->job.uid,
-                                 deq.force);
+                    RESMAND_INFO(
+                        "Received dequeue request by user %d for job "
+                        "%d owned by %d (force: %d), dequeueing job\n",
+                        deq.uid, deq.job_uuid, target_job->job.uid, deq.force);
                     // This searches the queue again (cf. find_job above), but
                     // it's fine since we hold mut_q throughout
                     queued_job *deq_job = remove_job(&q, deq.job_uuid);
@@ -173,36 +176,40 @@ int handle_client(int soc_client) { /*{{{*/
             pthread_mutex_lock(&mut_rj);
 
             if (!running_job) {
-                RESMAND_INFO("Received manual release request by user %d, but "
-                             "server is not reserved. Nothing to do.\n",
-                             rel.uid)
+                RESMAND_INFO(
+                    "Received manual release request by user %d, but "
+                    "server is not reserved. Nothing to do.\n",
+                    rel.uid)
                 resp.status = STATUS_REL_OK_SERVER_IDLE;
             } else {
                 if (running_job->job.uid == rel.uid) {
                     // Requesting user owns the job, ok
-                    RESMAND_INFO("Received manual release request by user %d "
-                                 "for their currently running job %d, "
-                                 "releasing lock\n",
-                                 rel.uid, running_job->job.job_uuid);
+                    RESMAND_INFO(
+                        "Received manual release request by user %d "
+                        "for their currently running job %d, "
+                        "releasing lock\n",
+                        rel.uid, running_job->job.job_uuid);
                     running_job->manually_released = 1;
                     resp.status = STATUS_OK;
                 } else {
                     // Requesting user does not own the job, require force
                     if (rel.force) {
-                        RESMAND_INFO("Received manual release request by user "
-                                     "%d for current running job %d owned by "
-                                     "%d (force: %d), releasing lock\n",
-                                     rel.uid, running_job->job.uid,
-                                     running_job->job.job_uuid, rel.force);
+                        RESMAND_INFO(
+                            "Received manual release request by user "
+                            "%d for current running job %d owned by "
+                            "%d (force: %d), releasing lock\n",
+                            rel.uid, running_job->job.uid,
+                            running_job->job.job_uuid, rel.force);
                         running_job->manually_released = 1;
                         resp.status = STATUS_OK;
                     } else {
-                        RESMAND_ERROR("Received manual release request by user "
-                                      "%d for current running job %d owned by "
-                                      "%d (force: %d), refusing to release "
-                                      "lock\n",
-                                      rel.uid, running_job->job.job_uuid,
-                                      running_job->job.uid, rel.force);
+                        RESMAND_ERROR(
+                            "Received manual release request by user "
+                            "%d for current running job %d owned by "
+                            "%d (force: %d), refusing to release "
+                            "lock\n",
+                            rel.uid, running_job->job.job_uuid,
+                            running_job->job.uid, rel.force);
                         resp.status = STATUS_REL_FAIL_NOT_YOUR_JOB;
                     }
                 }

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -121,11 +121,11 @@ int handle_client(int soc_client) { /*{{{*/
             send_status(soc_client, &resp);
             break;
         case IPCREQ_VIEW_QUEUE:
-            info_request info = req.info;
+            const info_request info = req.info;
             send_queue_info(soc_client, info.n_view);
             break;
         case IPCREQ_DEQUEUE:
-            dequeue_request deq = req.deq;
+            const dequeue_request deq = req.deq;
             RESMAND_INFO("Received dequeue request for job %d\n", deq.job_uuid);
 
             pthread_mutex_lock(&mut_rj);
@@ -153,7 +153,7 @@ int handle_client(int soc_client) { /*{{{*/
             send_status(soc_client, &resp);
             break;
         case IPCREQ_RELEASE:
-            release_request rel = req.rel;
+            const release_request rel = req.rel;
 
             if (!running_job) {
                 RESMAND_INFO("Received manual release request by user %d, but "

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -159,7 +159,7 @@ int handle_client(int soc_client) { /*{{{*/
                 RESMAND_INFO("Received manual release request by user %d, but "
                              "server is not reserved. Nothing to do.\n",
                              rel.uid)
-                resp.status = STATUS_OK;
+                resp.status = STATUS_REL_OK_SERVER_IDLE;
             } else {
                 RESMAND_INFO("Received manual release request by user %d (force: "
                              "%d), cancelling current running job %d\n",

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -207,16 +207,16 @@ int handle_client(const int soc_client) { /*{{{*/
                 RESMAND_INFO(
                     "Received manual release request by user %d, but "
                     "server is not reserved. Nothing to do.\n",
-                    rel.uid)
+                    client_uid)
                 resp.status = STATUS_REL_OK_SERVER_IDLE;
             } else {
-                if (running_job->job.uid == rel.uid) {
+                if (running_job->job.uid == client_uid) {
                     // Requesting user owns the job, ok
                     RESMAND_INFO(
                         "Received manual release request by user %d "
                         "for their currently running job %d, "
                         "releasing lock\n",
-                        rel.uid, running_job->job.job_uuid);
+                        client_uid, running_job->job.job_uuid);
                     running_job->manually_released = 1;
                     resp.status = STATUS_OK;
                 } else {
@@ -226,7 +226,7 @@ int handle_client(const int soc_client) { /*{{{*/
                             "Received manual release request by user "
                             "%d for current running job %d owned by "
                             "%d (force: %d), releasing lock\n",
-                            rel.uid, running_job->job.uid,
+                            client_uid, running_job->job.uid,
                             running_job->job.job_uuid, rel.force);
                         running_job->manually_released = 1;
                         resp.status = STATUS_OK;
@@ -236,7 +236,7 @@ int handle_client(const int soc_client) { /*{{{*/
                             "%d for current running job %d owned by "
                             "%d (force: %d), refusing to release "
                             "lock\n",
-                            rel.uid, running_job->job.job_uuid,
+                            client_uid, running_job->job.job_uuid,
                             running_job->job.uid, rel.force);
                         resp.status = STATUS_REL_FAIL_NOT_YOUR_JOB;
                     }

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -141,13 +141,17 @@ int handle_client(int soc_client) { /*{{{*/
                     RESMAND_ERROR("Failed to dequeue job %d: not found in queue"
                                   "\n", deq.job_uuid);
                     resp.status = STATUS_DEQ_FAIL_NO_SUCH_JOB;
-                } else if (target_job->job.uid != deq.uid) {
-                    RESMAND_ERROR("Refusing to dequeue job %d owned by %d\n",
-                                  target_job->job.job_uuid, target_job->job.uid);
+                } else if (target_job->job.uid != deq.uid && !deq.force) {
+                    RESMAND_ERROR("Refusing to dequeue job %d owned by %d "
+                                  "(force: %d)\n",
+                                  target_job->job.job_uuid, target_job->job.uid,
+                                  deq.force);
                     resp.status = STATUS_DEQ_FAIL_NOT_YOUR_JOB;
                 } else {
-                    RESMAND_INFO("Dequeueueueueing job %d\n",
-                                 target_job->job.job_uuid);
+                    RESMAND_INFO("Dequeueueueueing job %d owned by %d (force: "
+                                 "%d)\n",
+                                 target_job->job.job_uuid, target_job->job.uid,
+                                 deq.force)
                     // This searches the queue again (cf. find_job above), but
                     // it's fine since we hold mut_q throughout
                     queued_job *deq_job = remove_job(&q, deq.job_uuid);

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -126,7 +126,8 @@ int handle_client(int soc_client) { /*{{{*/
             break;
         case IPCREQ_DEQUEUE:
             const dequeue_request deq = req.deq;
-            RESMAND_INFO("Received dequeue request for job %d\n", deq.job_uuid);
+            RESMAND_INFO("Received dequeue request for job %d from user %d\n",
+                         deq.job_uuid, deq.uid);
 
             pthread_mutex_lock(&mut_rj);
             pthread_mutex_lock(&mut_q);
@@ -135,13 +136,21 @@ int handle_client(int soc_client) { /*{{{*/
                 RESMAND_ERROR("Refusing to dequeue currently running job\n")
                 resp.status = STATUS_DEQ_FAIL_JOB_CURRENTLY_RUNNING;
             } else {
-                queued_job *deq_job = remove_job(&q, deq.job_uuid);
-                if (!deq_job) {
+                queued_job *target_job = find_job(&q, deq.job_uuid);
+                if (!target_job) {
                     RESMAND_ERROR("Failed to dequeue job %d: not found in queue"
                                   "\n", deq.job_uuid);
                     resp.status = STATUS_DEQ_FAIL_NO_SUCH_JOB;
+                } else if (target_job->job.uid != deq.uid) {
+                    RESMAND_ERROR("Refusing to dequeue job %d owned by %d\n",
+                                  target_job->job.job_uuid, target_job->job.uid);
+                    resp.status = STATUS_DEQ_FAIL_NOT_YOUR_JOB;
                 } else {
-                    RESMAND_INFO("Dequeueueueueing job %d\n", deq_job->job.job_uuid);
+                    RESMAND_INFO("Dequeueueueueing job %d\n",
+                                 target_job->job.job_uuid);
+                    // This searches the queue again (cf. find_job above), but
+                    // it's fine since we hold mut_q throughout
+                    queued_job *deq_job = remove_job(&q, deq.job_uuid);
                     free_queued_job(deq_job);
                     resp.status = STATUS_OK;
                 }

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -78,43 +78,42 @@ int handle_client(int soc_client) { /*{{{*/
         job_descriptor job = req.job;
 
         if (job.job_type != JOB_CMD && job.job_type != JOB_TIMESLOT) {
-            RESMAND_ERROR("Unrecognised job type in request.\n");
+            RESMAND_ERROR("Invalid job type in request\n");
             goto _close;
         }
 
         job.job_uuid = next_uuid();
-        if (job.job_type == JOB_CMD) {
-            RESMAND_INFO(
-                "Received command job %d by user %d (pid: %d, msg: '%s')\n",
-                job.job_uuid, job.uid, job.cmd.pid, job.msg
-            );
-        } else {
-            RESMAND_INFO(
-                "Received timeslot job %d by user %d (time: %ds, msg: '%s')\n",
-                job.job_uuid, job.uid, job.timeslot.secs, job.msg
-            );
-        }
 
         switch (job.job_type) {
             case JOB_CMD:
+                RESMAND_INFO(
+                    "Received command job %d by user %d (pid: %d, msg: '%s')\n",
+                    job.job_uuid, job.uid, job.cmd.pid, job.msg
+                );
                 pthread_mutex_lock(&mut_q);
                 enq_job(&q, job);
                 pthread_mutex_unlock(&mut_q);
                 resp.status = STATUS_OK;
                 break;
             case JOB_TIMESLOT:
+                RESMAND_INFO(
+                    "Received timeslot job %d by user %d (time: %ds, msg: '%s')\n",
+                    job.job_uuid, job.uid, job.timeslot.secs, job.msg
+                );
+
                 if (running_job || peek_job(q, 0)) {
                     RESMAND_INFO(
-                        "Rejecting timeslot job %d for user %d: server is "
-                        "already reserved.\n",
-                        job.job_uuid, job.uid);
+                        "Rejecting timeslot job %d: server is already reserved\n",
+                        job.job_uuid
+                    );
                     resp.status = STATUS_FAIL;
-                } else {
-                    pthread_mutex_lock(&mut_q);
-                    enq_job(&q, job);
-                    pthread_mutex_unlock(&mut_q);
-                    resp.status = STATUS_OK;
+                    break;
                 }
+
+                pthread_mutex_lock(&mut_q);
+                enq_job(&q, job);
+                pthread_mutex_unlock(&mut_q);
+                resp.status = STATUS_OK;
                 break;
         }
 

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -142,12 +142,14 @@ int handle_client(int soc_client) { /*{{{*/
         release_request rel = req.rel;
 
         if (!running_job) {
-            RESMAND_INFO("Received manual release request, but server is not "
-                         "reserved. Nothing to do.\n")
+            RESMAND_INFO("Received manual release request by user %d, but "
+                         "server is not reserved. Nothing to do.\n",
+                         rel.uid)
             resp.status = STATUS_OK;
         } else {
-            RESMAND_INFO("Received manual release request (force=%d), cancelling current running job %d\n",
-                         rel.force, running_job->job.job_uuid);
+            RESMAND_INFO("Received manual release request by user %d (force: "
+                         "%d), cancelling current running job %d\n",
+                         rel.uid, rel.force, running_job->job.job_uuid);
             pthread_mutex_lock(&mut_rj);
             running_job->manually_released = 1;
             pthread_mutex_unlock(&mut_rj);

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -140,16 +140,20 @@ int handle_client(int soc_client) { /*{{{*/
         disp_status();
     } else if (req.req_type == IPCREQ_RELEASE) {
         release_request rel = req.rel;
-        RESMAND_INFO("Received manual release request\n");
 
         if (!running_job) {
+            RESMAND_INFO("Received manual release request, but server is not "
+                         "reserved. Nothing to do.\n")
             resp.status = STATUS_OK;
         } else {
-            printf("Releasing lock. Force=%d\n", rel.force);
+            RESMAND_INFO("Received manual release request (force=%d), cancelling current running job %d\n",
+                         rel.force, running_job->job.job_uuid);
             pthread_mutex_lock(&mut_rj);
             running_job->manually_released = 1;
             pthread_mutex_unlock(&mut_rj);
+            resp.status = STATUS_OK;
         }
+        send_status(soc_client, &resp);
     } else {
         RESMAND_ERROR("Invalid request type: %d\n", req.req_type);
         close(soc_client);

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -163,7 +163,7 @@ int handle_client(const int soc_client) { /*{{{*/
                 RESMAND_ERROR(
                     "Received dequeue request by user %d for job %d, "
                     "but refusing to dequeue currently running job\n",
-                    deq.uid, deq.job_uuid)
+                    client_uid, deq.job_uuid)
                 resp.status = STATUS_DEQ_FAIL_JOB_CURRENTLY_RUNNING;
             } else {
                 queued_job *target_job = find_job(&q, deq.job_uuid);
@@ -171,20 +171,20 @@ int handle_client(const int soc_client) { /*{{{*/
                     RESMAND_ERROR(
                         "Received dequeue request by user %d for job "
                         "%d, but no such job in queue\n",
-                        deq.uid, deq.job_uuid);
+                        client_uid, deq.job_uuid);
                     resp.status = STATUS_DEQ_FAIL_NO_SUCH_JOB;
-                } else if (target_job->job.uid != deq.uid && !deq.force) {
+                } else if (target_job->job.uid != client_uid && !deq.force) {
                     RESMAND_ERROR(
                         "Received dequeue request by user %d for job "
                         "%d owned by %d (force: %d), refusing to "
                         "dequeue\n",
-                        deq.uid, deq.job_uuid, target_job->job.uid, deq.force);
+                        client_uid, deq.job_uuid, target_job->job.uid, deq.force);
                     resp.status = STATUS_DEQ_FAIL_NOT_YOUR_JOB;
                 } else {
                     RESMAND_INFO(
                         "Received dequeue request by user %d for job "
                         "%d owned by %d (force: %d), dequeueing job\n",
-                        deq.uid, deq.job_uuid, target_job->job.uid, deq.force);
+                        client_uid, deq.job_uuid, target_job->job.uid, deq.force);
                     // This searches the queue again (cf. find_job above), but
                     // it's fine since we hold mut_q throughout
                     queued_job *deq_job = remove_job(&q, deq.job_uuid);

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -85,13 +85,13 @@ int handle_client(int soc_client) { /*{{{*/
         job.job_uuid = next_uuid();
         if (job.job_type == JOB_CMD) {
             RESMAND_INFO(
-                "new job CMD(uid=%d job_uuid=%d pid=%d msg=%s)\n",
-                job.uid, job.job_uuid, job.cmd.pid, job.msg
+                "Received command job %d by user %d (pid: %d, msg: '%s')\n",
+                job.job_uuid, job.uid, job.cmd.pid, job.msg
             );
         } else {
             RESMAND_INFO(
-                "new job TIMESLOT(uid=%d job_uuid=%d time=%ds msg=%s)\n",
-                job.uid, job.job_uuid, job.timeslot.secs, job.msg
+                "Received timeslot job %d by user %d (time: %ds, msg: '%s')\n",
+                job.job_uuid, job.uid, job.timeslot.secs, job.msg
             );
         }
 
@@ -105,7 +105,7 @@ int handle_client(int soc_client) { /*{{{*/
             case JOB_TIMESLOT:
                 if (running_job || peek_job(q, 0)) {
                     RESMAND_INFO(
-                        "User %d wanted a timeslot, but server is "
+                        "User %d requested a timeslot, but server is "
                         "already reserved.\n",
                         job.uid);
                     resp.status = STATUS_FAIL;
@@ -125,13 +125,13 @@ int handle_client(int soc_client) { /*{{{*/
         send_queue_info(soc_client, info.n_view);
     } else if (req.req_type == IPCREQ_DEQUEUE) {
         dequeue_request deq = req.deq;
-        RESMAND_INFO("dequeue request (job_uuid=%d)\n", deq.job_uuid);
+        RESMAND_INFO("Received dequeue request for job %d\n", deq.job_uuid);
 
         pthread_mutex_lock(&mut_q);
         queued_job *deq_job = remove_job(&q, deq.job_uuid);
         pthread_mutex_unlock(&mut_q);
 
-        RESMAND_INFO("Dequeued job = %lu\n", (unsigned long)deq_job);
+        RESMAND_INFO("Dequeued job %lu\n", (unsigned long)deq_job);
 
         free_queued_job(deq_job);
         resp.status = deq_job ? STATUS_OK : STATUS_FAIL;
@@ -140,7 +140,7 @@ int handle_client(int soc_client) { /*{{{*/
         disp_status();
     } else if (req.req_type == IPCREQ_RELEASE) {
         release_request rel = req.rel;
-        RESMAND_INFO("release request\n");
+        RESMAND_INFO("Received manual release request\n");
 
         if (!running_job) {
             resp.status = STATUS_OK;
@@ -151,7 +151,7 @@ int handle_client(int soc_client) { /*{{{*/
             pthread_mutex_unlock(&mut_rj);
         }
     } else {
-        RESMAND_ERROR("Incorrect request type: %d\n", req.req_type);
+        RESMAND_ERROR("Invalid request type: %d\n", req.req_type);
         close(soc_client);
         return -1;
     }

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -155,20 +155,46 @@ int handle_client(int soc_client) { /*{{{*/
         case IPCREQ_RELEASE:
             const release_request rel = req.rel;
 
+            pthread_mutex_lock(&mut_rj);
+
             if (!running_job) {
                 RESMAND_INFO("Received manual release request by user %d, but "
                              "server is not reserved. Nothing to do.\n",
                              rel.uid)
                 resp.status = STATUS_REL_OK_SERVER_IDLE;
             } else {
-                RESMAND_INFO("Received manual release request by user %d (force: "
-                             "%d), cancelling current running job %d\n",
-                             rel.uid, rel.force, running_job->job.job_uuid);
-                pthread_mutex_lock(&mut_rj);
-                running_job->manually_released = 1;
-                pthread_mutex_unlock(&mut_rj);
-                resp.status = STATUS_OK;
+                if (running_job->job.uid == rel.uid) {
+                    // Requesting user owns the job, ok
+                    RESMAND_INFO("Received manual release request by user %d "
+                                 "for their currently running job %d, "
+                                 "releasing lock\n",
+                                 rel.uid, running_job->job.job_uuid);
+                    running_job->manually_released = 1;
+                    resp.status = STATUS_OK;
+                } else {
+                    // Requesting user does not own the job, require force
+                    if (rel.force) {
+                        RESMAND_INFO("Received manual release request by user "
+                                     "%d for current running job %d owned by "
+                                     "%d (force: %d), releasing lock\n",
+                                     rel.uid, running_job->job.uid,
+                                     running_job->job.job_uuid, rel.force);
+                        running_job->manually_released = 1;
+                        resp.status = STATUS_OK;
+                    } else {
+                        RESMAND_ERROR("Received manual release request by user "
+                                      "%d for current running job %d owned by "
+                                      "%d (force: %d), refusing to release "
+                                      "lock\n",
+                                      rel.uid, running_job->job.job_uuid,
+                                      running_job->job.uid, rel.force);
+                        resp.status = STATUS_REL_FAIL_NOT_YOUR_JOB;
+                    }
+                }
             }
+
+            pthread_mutex_unlock(&mut_rj);
+
             send_status(soc_client, &resp);
             break;
         default:

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -25,7 +25,7 @@ int make_soc_listen(const char *addr) { /*{{{*/
     sa_local.sun_family = AF_UNIX;
     sa_local.sun_path[0] = '\0';
     strncpy(sa_local.sun_path + 1, addr, strlen(addr));
-    
+
     sa_len = offsetof(struct sockaddr_un, sun_path) + 1 + strlen(addr);
 
     if (bind(soc_listen, (struct sockaddr *)&sa_local, sa_len) < 0) {
@@ -126,14 +126,28 @@ int handle_client(int soc_client) { /*{{{*/
         dequeue_request deq = req.deq;
         RESMAND_INFO("Received dequeue request for job %d\n", deq.job_uuid);
 
+        pthread_mutex_lock(&mut_rj);
         pthread_mutex_lock(&mut_q);
-        queued_job *deq_job = remove_job(&q, deq.job_uuid);
+
+        if (running_job && running_job->job.job_uuid == deq.job_uuid) {
+            RESMAND_ERROR("Refusing to dequeue currently running job\n")
+            resp.status = STATUS_DEQ_FAIL_JOB_CURRENTLY_RUNNING;
+        } else {
+            queued_job *deq_job = remove_job(&q, deq.job_uuid);
+            if (!deq_job) {
+                RESMAND_ERROR("Failed to dequeue job %d: not found in queue"
+                              "\n", deq.job_uuid);
+                resp.status = STATUS_DEQ_FAIL_NO_SUCH_JOB;
+            } else {
+                RESMAND_INFO("Dequeueueueueing job %d\n", deq_job->job.job_uuid);
+                free_queued_job(deq_job);
+                resp.status = STATUS_OK;
+            }
+        }
+
         pthread_mutex_unlock(&mut_q);
+        pthread_mutex_unlock(&mut_rj);
 
-        RESMAND_INFO("Dequeued job %lu\n", (unsigned long)deq_job);
-
-        free_queued_job(deq_job);
-        resp.status = deq_job ? STATUS_OK : STATUS_FAIL;
         send_status(soc_client, &resp);
 
         disp_status();

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -126,32 +126,34 @@ int handle_client(int soc_client) { /*{{{*/
             break;
         case IPCREQ_DEQUEUE:
             const dequeue_request deq = req.deq;
-            RESMAND_INFO("Received dequeue request for job %d from user %d\n",
-                         deq.job_uuid, deq.uid);
 
             pthread_mutex_lock(&mut_rj);
             pthread_mutex_lock(&mut_q);
 
             if (running_job && running_job->job.job_uuid == deq.job_uuid) {
-                RESMAND_ERROR("Refusing to dequeue currently running job\n")
+                RESMAND_ERROR("Received dequeue request by user %d for job %d, "
+                              "but refusing to dequeue currently running job\n",
+                              deq.uid, deq.job_uuid)
                 resp.status = STATUS_DEQ_FAIL_JOB_CURRENTLY_RUNNING;
             } else {
                 queued_job *target_job = find_job(&q, deq.job_uuid);
                 if (!target_job) {
-                    RESMAND_ERROR("Failed to dequeue job %d: not found in queue"
-                                  "\n", deq.job_uuid);
+                    RESMAND_ERROR("Received dequeue request by user %d for job "
+                                  "%d, but no such job in queue\n",
+                                  deq.uid, deq.job_uuid);
                     resp.status = STATUS_DEQ_FAIL_NO_SUCH_JOB;
                 } else if (target_job->job.uid != deq.uid && !deq.force) {
-                    RESMAND_ERROR("Refusing to dequeue job %d owned by %d "
-                                  "(force: %d)\n",
-                                  target_job->job.job_uuid, target_job->job.uid,
+                    RESMAND_ERROR("Received dequeue request by user %d for job "
+                                  "%d owned by %d (force: %d), refusing to "
+                                  "dequeue\n",
+                                  deq.uid, deq.job_uuid, target_job->job.uid,
                                   deq.force);
                     resp.status = STATUS_DEQ_FAIL_NOT_YOUR_JOB;
                 } else {
-                    RESMAND_INFO("Dequeueueueueing job %d owned by %d (force: "
-                                 "%d)\n",
-                                 target_job->job.job_uuid, target_job->job.uid,
-                                 deq.force)
+                    RESMAND_INFO("Received dequeue request by user %d for job "
+                                 "%d owned by %d (force: %d), dequeueing job\n",
+                                 deq.uid, deq.job_uuid, target_job->job.uid,
+                                 deq.force);
                     // This searches the queue again (cf. find_job above), but
                     // it's fine since we hold mut_q throughout
                     queued_job *deq_job = remove_job(&q, deq.job_uuid);

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -105,9 +105,9 @@ int handle_client(int soc_client) { /*{{{*/
             case JOB_TIMESLOT:
                 if (running_job || peek_job(q, 0)) {
                     RESMAND_INFO(
-                        "User %d requested a timeslot, but server is "
+                        "Rejecting timeslot job %d for user %d: server is "
                         "already reserved.\n",
-                        job.uid);
+                        job.job_uuid, job.uid);
                     resp.status = STATUS_FAIL;
                 } else {
                     pthread_mutex_lock(&mut_q);

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -1,4 +1,5 @@
 // vim: fdm=marker
+#include <sys/pidfd.h>
 #include <sys/socket.h>
 #include <sys/stat.h> /* chmod */
 #include <sys/un.h>
@@ -75,6 +76,31 @@ int handle_client(const int soc_client) { /*{{{*/
         return -1;
     }
 
+    // Use SO_PEERPIDFD to obtain a pidfd to retrieve information about the
+    // connecting client process.
+    int pidfd = -1;
+    socklen_t len = sizeof(pidfd);
+    if (getsockopt(soc_client, SOL_SOCKET, SO_PEERPIDFD, &pidfd, &len) == -1) {
+        perror("getsockopt(SO_PEERPIDFD)");
+        close(soc_client);
+        return -1;
+    }
+    if (pidfd < 0) {
+        RESMAND_ERROR("Failed to get pidfd of connected client")
+        close(soc_client);
+        return -1;
+    }
+    struct pidfd_info client_info;
+    if (ioctl(pidfd, PIDFD_GET_INFO, &client_info) == -1) {
+        perror("ioctl(PIDFD_GET_INFO)");
+        close(pidfd);
+        close(soc_client);
+        return -1;
+    }
+
+    const pid_t client_pid = (pid_t)client_info.pid;
+    const uid_t client_uid = client_info.ruid;  // Use the Real UID
+
     switch (req.req_type) {
         case IPCREQ_JOB:
             job_descriptor job = req.job;
@@ -85,13 +111,15 @@ int handle_client(const int soc_client) { /*{{{*/
             }
 
             job.job_uuid = next_uuid();
+            job.uid = client_uid;
 
             switch (job.job_type) {
                 case JOB_CMD:
                     RESMAND_INFO(
                         "Received command job %d by user %d (pid: %d, msg: "
                         "'%s')\n",
-                        job.job_uuid, job.uid, job.cmd.pid, job.msg);
+                        job.job_uuid, job.uid, client_pid, job.msg);
+                    job.cmd.pidfd = pidfd;
                     pthread_mutex_lock(&mut_q);
                     enq_job(&q, job);
                     pthread_mutex_unlock(&mut_q);

--- a/server/ipc.c
+++ b/server/ipc.c
@@ -127,8 +127,8 @@ int handle_client(int soc_client) { /*{{{*/
         case IPCREQ_DEQUEUE:
             const dequeue_request deq = req.deq;
 
-            pthread_mutex_lock(&mut_rj);
             pthread_mutex_lock(&mut_q);
+            pthread_mutex_lock(&mut_rj);
 
             if (running_job && running_job->job.job_uuid == deq.job_uuid) {
                 RESMAND_ERROR("Received dequeue request by user %d for job %d, "
@@ -162,8 +162,8 @@ int handle_client(int soc_client) { /*{{{*/
                 }
             }
 
-            pthread_mutex_unlock(&mut_q);
             pthread_mutex_unlock(&mut_rj);
+            pthread_mutex_unlock(&mut_q);
 
             send_status(soc_client, &resp);
             break;

--- a/server/queue.c
+++ b/server/queue.c
@@ -5,8 +5,8 @@
 
 /* Take a pointer to the job at the front of the queue, without removing it.
  * An offset can be specified, if a job further in the queue is needed.
- * Returns NULL if the queue is the requested queue position is empty. */
-const queued_job *peek_job(queued_job *q, int off) { /*{{{*/
+ * Returns NULL if the requested queue position is empty. */
+const queued_job *peek_job(const queued_job *q, const int off) { /*{{{*/
     for (int i = 0; i < off && q; i++, q = q->next)
         ;
 
@@ -34,7 +34,7 @@ queued_job *find_job(queued_job **q, const uuid_t uuid) {
 }
 
 /* Remove a job from the middle of the queue with a given UUID. */
-queued_job *remove_job(queued_job **q, uuid_t uuid) {/*{{{*/
+queued_job *remove_job(queued_job **q, const uuid_t uuid) {/*{{{*/
     queued_job *ret = *q;
     queued_job *prev = NULL;
 
@@ -48,12 +48,12 @@ queued_job *remove_job(queued_job **q, uuid_t uuid) {/*{{{*/
     }
 
     return NULL; /* Not found */
-}/*}}}*/
+} /*}}}*/
 
 /* Pushes a new job to the back of the queue.
  * Returns the new length of the queue. */
-int enq_job(queued_job **q, job_descriptor job) { /*{{{*/
-    queued_job *qjob = (queued_job *)malloc(sizeof(queued_job));
+int enq_job(queued_job **q, const job_descriptor job) { /*{{{*/
+    queued_job *qjob = malloc(sizeof(queued_job));
 
     if (!qjob) {
         perror("malloc");
@@ -64,10 +64,10 @@ int enq_job(queued_job **q, job_descriptor job) { /*{{{*/
     qjob->t_ended = 0;
     qjob->t_started = 0;
     qjob->manually_released = 0;
+    qjob->next = NULL;
 
     if (!*q) {
         *q = qjob;
-        qjob->next = NULL;
         return 1;
     }
 
@@ -76,7 +76,6 @@ int enq_job(queued_job **q, job_descriptor job) { /*{{{*/
         ;
 
     (*q)->next = qjob;
-    qjob->next = NULL;
     return i;
 } /*}}}*/
 
@@ -89,4 +88,4 @@ int queue_len(queued_job *q) {/* {{{ */
             ;
     }
     return qlen;
-}/* }}} */
+} /* }}} */

--- a/server/queue.c
+++ b/server/queue.c
@@ -61,8 +61,6 @@ int enq_job(queued_job **q, const job_descriptor job) { /*{{{*/
     }
 
     qjob->job = job;
-    qjob->t_ended = 0;
-    qjob->t_started = 0;
     qjob->manually_released = 0;
     qjob->next = NULL;
 

--- a/server/queue.c
+++ b/server/queue.c
@@ -22,6 +22,17 @@ queued_job *deq_job(queued_job **q) { /*{{{*/
     return ret;
 } /*}}}*/
 
+/* Search the queue for a job with a given UUID. */
+queued_job *find_job(queued_job **q, const uuid_t uuid) {
+    for (queued_job *ret = *q; ret; ret = ret->next) {
+        if (uuid == ret->job.job_uuid) {
+            return ret;
+        }
+    }
+
+    return NULL; /* Not found */
+}
+
 /* Remove a job from the middle of the queue with a given UUID. */
 queued_job *remove_job(queued_job **q, uuid_t uuid) {/*{{{*/
     queued_job *ret = *q;

--- a/server/server.c
+++ b/server/server.c
@@ -112,7 +112,6 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
                     }
 
                     if (job_exited || running_job->manually_released) {
-                        close(running_job->job.cmd.pidfd);
                         free_queued_job(running_job);
                         goto try_start;
                     }
@@ -142,7 +141,6 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
                                 "queue, maybe the process exited?",
                                 running_job->job.job_uuid)
                             // Try next job in queue without delay
-                            close(running_job->job.cmd.pidfd);
                             free_queued_job(running_job);
                             goto try_start;
                         }
@@ -163,7 +161,6 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
                                 "queue, trying the next one",
                                 running_job->job.job_uuid);
                             // Try next job in queue instead
-                            close(running_job->job.cmd.pidfd);
                             free_queued_job(running_job);
                             goto try_start;
                         }
@@ -242,4 +239,9 @@ void sigint_handler(int sig UNUSED) { /*{{{*/
     exit(EXIT_SUCCESS);
 } /*}}}*/
 
-void free_queued_job(queued_job* qjob) { free(qjob); }
+void free_queued_job(queued_job* qjob) {
+    if (qjob->job.job_type == JOB_CMD) {
+        close(qjob->job.cmd.pidfd);
+    }
+    free(qjob);
+}

--- a/server/server.c
+++ b/server/server.c
@@ -74,16 +74,12 @@ int main(void) { /*{{{*/
 void* dispatcher(void* args UNUSED) { /*{{{*/
     pid_t pid;
     queued_job* next_job;
-    int is_running;
 
     while (true) {
         sleep(POLL_DELAY);
 
         pthread_mutex_lock(&mut_rj);
-        is_running = !!running_job;
-        pthread_mutex_unlock(&mut_rj);
-
-        if (is_running) {
+        if (running_job) {
             /* There is a currently running job. Time or Cmd.
              * This code checks if the current job is ready to end. */
 
@@ -94,30 +90,26 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
                         RESMAND_INFO("Timeslot job %d finished\n",
                                      running_job->job.job_uuid);
 
-                        pthread_mutex_lock(&mut_rj);
                         free_queued_job(running_job);
                         running_job = NULL;
-                        pthread_mutex_unlock(&mut_rj);
 
                         goto try_start;
                     }
                     break;
                 }
                 case JOB_CMD: {
-                    pthread_mutex_lock(&mut_rj);
                     if (running_job->manually_released) {
                         free_queued_job(running_job);
                         running_job = NULL;
-                        pthread_mutex_unlock(&mut_rj);
 
                         goto try_start;
                     }
-                    pthread_mutex_unlock(&mut_rj);
 
                     pid = running_job->job.cmd.pid;
 
                     if (kill(pid, 0) == 0) {
                         /* Job is still alive, just wait. */
+                        pthread_mutex_unlock(&mut_rj);
                         continue;
                     } else if (errno == ESRCH) {
                         /* The job has ended */
@@ -126,10 +118,8 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
 
                         /* TODO: Here we could add the finished job to a
                          * persistent database */
-                        pthread_mutex_lock(&mut_rj);
                         free_queued_job(running_job);
                         running_job = NULL;
-                        pthread_mutex_unlock(&mut_rj);
 
                         goto try_start;  // Skip the timeout to try to start a
                                          // new job.
@@ -149,7 +139,6 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
             next_job = deq_job(&q);
             pthread_mutex_unlock(&mut_q);
 
-            pthread_mutex_lock(&mut_rj);
             running_job = next_job;
 
             if (running_job) {
@@ -180,9 +169,8 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
                                       running_job->job.job_type);
                 }
             }
-
-            pthread_mutex_unlock(&mut_rj);
         }
+        pthread_mutex_unlock(&mut_rj);
     }
 } /*}}}*/
 

--- a/server/server.c
+++ b/server/server.c
@@ -68,7 +68,7 @@ int main(void) { /*{{{*/
 } /*}}}*/
 
 /* The dispatcher is responsible for polling the currently running job (if one
- * exists) to check when it ends. When there is no job (the server is free,)
+ * exists) to check when it ends. When there is no job (the server is free),
  * then this function begins a new one.
  * It's meant to be run as a thread. */
 void* dispatcher(void* args UNUSED) { /*{{{*/
@@ -89,7 +89,8 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
 
             switch (running_job->job.job_type) {
                 case JOB_TIMESLOT: {
-                    if (running_job->manually_released || time(NULL) >= running_job->job.timeslot.t_end) {
+                    if (running_job->manually_released ||
+                        time(NULL) >= running_job->job.timeslot.t_end) {
                         RESMAND_INFO("Timeslot job %d finished\n",
                                      running_job->job.job_uuid);
 
@@ -155,11 +156,10 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
                 switch (running_job->job.job_type) {
                     case JOB_CMD:
                         RESMAND_INFO(
-                            "Starting command job %d (pid: %d) for user %d: '%s'\n",
-                            running_job->job.job_uuid,
-                            running_job->job.cmd.pid,
-                            running_job->job.uid,
-                            running_job->job.msg);
+                            "Starting command job %d (pid: %d) for user %d: "
+                            "'%s'\n",
+                            running_job->job.job_uuid, running_job->job.cmd.pid,
+                            running_job->job.uid, running_job->job.msg);
                         /* Tell the waiting job stub to start the desired
                          * process */
                         running_job->job.t_started = time(NULL);
@@ -186,7 +186,7 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
     }
 } /*}}}*/
 
-int send_queue_info(int soc_client, unsigned int count) { /* {{{ */
+int send_queue_info(const int soc_client, const unsigned int count) { /* {{{ */
     pthread_mutex_lock(&mut_q);
     pthread_mutex_lock(&mut_rj);
 

--- a/server/server.c
+++ b/server/server.c
@@ -35,7 +35,6 @@ int main(void) { /*{{{*/
         "Version 0.0\n");
     fflush(stdout);
 
-    disp_status();
     int soc_listen, soc_client;
     struct sockaddr_un sa_client = {0};
     unsigned int soc_len = sizeof(sa_client);
@@ -67,8 +66,6 @@ int main(void) { /*{{{*/
         }
     }
 } /*}}}*/
-
-void disp_status(void) { /* {{{ */ return; } /* }}} */
 
 /* The dispatcher is responsible for polling the currently running job (if one
  * exists) to check when it ends. When there is no job (the server is free,)
@@ -125,7 +122,6 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
                         /* The job has ended */
                         RESMAND_INFO("Command job %d finished\n",
                                      running_job->job.job_uuid);
-                        disp_status();
 
                         /* TODO: Here we could add the finished job to a
                          * persistent database */

--- a/server/server.c
+++ b/server/server.c
@@ -51,7 +51,7 @@ int main(void) { /*{{{*/
     }
 
     if (pthread_create(&thr_dispatcher, NULL, &dispatcher, NULL) != 0) {
-        fprintf(stderr, "pthread_create failed!\n");
+        fprintf(stderr, "pthread_create failed\n");
         return EXIT_FAILURE;
     }
 
@@ -63,7 +63,7 @@ int main(void) { /*{{{*/
         }
 
         if (handle_client(soc_client) < 0) {
-            RESMAND_ERROR("Failed while handling a new client.\n");
+            RESMAND_ERROR("Failed while handling a new client\n");
         }
     }
 } /*}}}*/
@@ -93,7 +93,7 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
             switch (running_job->job.job_type) {
                 case JOB_TIMESLOT: {
                     if (running_job->manually_released || time(NULL) >= running_job->job.timeslot.t_end) {
-                        RESMAND_INFO("Timeslot job %d finished.\n",
+                        RESMAND_INFO("Timeslot job %d finished\n",
                                      running_job->job.job_uuid);
 
                         pthread_mutex_lock(&mut_rj);
@@ -159,7 +159,7 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
                 switch (running_job->job.job_type) {
                     case JOB_CMD:
                         RESMAND_INFO(
-                            "Starting command job %d (pid=%d) for user %d: '%s'\n",
+                            "Starting command job %d (pid: %d) for user %d: '%s'\n",
                             running_job->job.job_uuid,
                             running_job->job.cmd.pid,
                             running_job->job.uid,
@@ -180,7 +180,7 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
                             running_job->job.timeslot.secs;
                         break;
                     default:
-                        RESMAND_ERROR("Got malformed job type: %d.\n",
+                        RESMAND_ERROR("Received invalid job type: %d\n",
                                       running_job->job.job_type);
                 }
             }
@@ -226,7 +226,7 @@ int send_queue_info(int soc_client, unsigned int count) { /* {{{ */
     pthread_mutex_unlock(&mut_rj);
 
     if (send(soc_client, ser_buf, buf_len, 0) < 0) {
-        RESMAND_ERROR("Failed sending queue response to client.\n");
+        RESMAND_ERROR("Failed sending queue response to client\n");
         free(ser_buf);
         return -1;
     }
@@ -240,7 +240,7 @@ fail:
 } /* }}} */
 
 void sigint_handler(int sig UNUSED) { /*{{{*/
-    printf("Caught SIGINT: exiting.\n");
+    printf("Caught SIGINT, exiting\n");
     exit(EXIT_SUCCESS);
 } /*}}}*/
 

--- a/server/server.c
+++ b/server/server.c
@@ -2,9 +2,10 @@
 #include "server.h"
 
 #include <assert.h>
-#include <errno.h>
+#include <poll.h>
 #include <signal.h>
 #include <stdlib.h>
+#include <sys/pidfd.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
@@ -72,7 +73,6 @@ int main(void) { /*{{{*/
  * then this function begins a new one.
  * It's meant to be run as a thread. */
 void* dispatcher(void* args UNUSED) { /*{{{*/
-    pid_t pid;
     queued_job* next_job;
 
     while (true) {
@@ -82,45 +82,41 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
         if (running_job) {
             /* There is a currently running job. Time or Cmd.
              * This code checks if the current job is ready to end. */
-
             switch (running_job->job.job_type) {
                 case JOB_TIMESLOT: {
                     if (running_job->manually_released ||
                         time(NULL) >= running_job->job.timeslot.t_end) {
                         RESMAND_INFO("Timeslot job %d finished\n",
                                      running_job->job.job_uuid);
-
                         free_queued_job(running_job);
                         goto try_start;
                     }
                     break;
                 }
                 case JOB_CMD: {
-                    if (running_job->manually_released) {
+                    /* The pidfd becomes readable when the task that it refers
+                     * to has terminated (see open(2)), use poll() to check. */
+                    bool job_exited = false;
+                    struct pollfd pollfd = {
+                        .fd = running_job->job.cmd.pidfd,
+                        .events = POLLIN,
+                    };
+                    const int r = poll(&pollfd, 1, 0);
+                    if (r == -1) {
+                        perror("poll");
+                    } else if (pollfd.revents & POLLIN) {
+                        // The job has ended, pidfd became readable
+                        RESMAND_INFO("Command job %d finished\n",
+                                     running_job->job.job_uuid);
+                        job_exited = true;
+                    }
+
+                    if (job_exited || running_job->manually_released) {
+                        close(running_job->job.cmd.pidfd);
                         free_queued_job(running_job);
                         goto try_start;
                     }
 
-                    pid = running_job->job.cmd.pid;
-
-                    if (kill(pid, 0) == 0) {
-                        /* Job is still alive, just wait. */
-                        pthread_mutex_unlock(&mut_rj);
-                        continue;
-                    } else if (errno == ESRCH) {
-                        /* The job has ended */
-                        RESMAND_INFO("Command job %d finished\n",
-                                     running_job->job.job_uuid);
-
-                        /* TODO: Here we could add the finished job to a
-                         * persistent database */
-                        free_queued_job(running_job);
-                        goto try_start;  // Skip the timeout to try to start a
-                                         // new job.
-                    } else {
-                        perror("kill");
-                        exit(EXIT_FAILURE);
-                    }
                     break;
                 }
             }
@@ -138,15 +134,39 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
             if (running_job) {
                 switch (running_job->job.job_type) {
                     case JOB_CMD:
+                        const pid_t target_pid =
+                            pidfd_getpid(running_job->job.cmd.pidfd);
+                        if (target_pid == -1) {
+                            RESMAND_ERROR(
+                                "Failed to get PID for next command job %d in "
+                                "queue, maybe the process exited?",
+                                running_job->job.job_uuid)
+                            // Try next job in queue without delay
+                            close(running_job->job.cmd.pidfd);
+                            free_queued_job(running_job);
+                            goto try_start;
+                        }
+
                         RESMAND_INFO(
                             "Starting command job %d (pid: %d) for user %d: "
                             "'%s'\n",
-                            running_job->job.job_uuid, running_job->job.cmd.pid,
+                            running_job->job.job_uuid, target_pid,
                             running_job->job.uid, running_job->job.msg);
-                        /* Tell the waiting job stub to start the desired
-                         * process */
                         running_job->job.t_started = time(NULL);
-                        kill(running_job->job.cmd.pid, SIGUSR1);
+
+                        // Signal the waiting job stub to start executing
+                        if (pidfd_send_signal(running_job->job.cmd.pidfd,
+                                              SIGUSR1, NULL, 0) == -1) {
+                            perror("pidfd_send_signal");
+                            RESMAND_ERROR(
+                                "Failed to signal next command job %d in "
+                                "queue, trying the next one",
+                                running_job->job.job_uuid);
+                            // Try next job in queue instead
+                            close(running_job->job.cmd.pidfd);
+                            free_queued_job(running_job);
+                            goto try_start;
+                        }
                         break;
                     case JOB_TIMESLOT:
                         RESMAND_INFO(

--- a/server/server.c
+++ b/server/server.c
@@ -33,6 +33,7 @@ int main(void) { /*{{{*/
         " |  _ <  __/\\__ \\ | | | | | (_| | | | |\n"
         " |_| \\_\\___||___/_| |_| |_|\\__,_|_| |_|\n"
         "Version 0.0\n");
+    fflush(stdout);
 
     disp_status();
     int soc_listen, soc_client;

--- a/server/server.c
+++ b/server/server.c
@@ -51,7 +51,7 @@ int main(void) { /*{{{*/
     }
 
     if (pthread_create(&thr_dispatcher, NULL, &dispatcher, NULL) != 0) {
-        fprintf(stderr, "pthread_create failed!.\n");
+        fprintf(stderr, "pthread_create failed!\n");
         return EXIT_FAILURE;
     }
 

--- a/server/server.c
+++ b/server/server.c
@@ -3,9 +3,7 @@
 
 #include <assert.h>
 #include <errno.h>
-#include <pwd.h>
 #include <signal.h>
-#include <stdbool.h>
 #include <stdlib.h>
 #include <sys/socket.h>
 #include <sys/un.h>

--- a/server/server.c
+++ b/server/server.c
@@ -93,7 +93,8 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
             switch (running_job->job.job_type) {
                 case JOB_TIMESLOT: {
                     if (running_job->manually_released || time(NULL) >= running_job->job.timeslot.t_end) {
-                        RESMAND_INFO("Job finished timeslot.\n");
+                        RESMAND_INFO("Timeslot job %d finished.\n",
+                                     running_job->job.job_uuid);
 
                         pthread_mutex_lock(&mut_rj);
                         free_queued_job(running_job);
@@ -122,7 +123,7 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
                         continue;
                     } else if (errno == ESRCH) {
                         /* The job has ended */
-                        RESMAND_INFO("Job finished, uuid=%d\n",
+                        RESMAND_INFO("Command job %d finished\n",
                                      running_job->job.job_uuid);
                         disp_status();
 
@@ -158,10 +159,11 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
                 switch (running_job->job.job_type) {
                     case JOB_CMD:
                         RESMAND_INFO(
-                            "Sending start signal to job(pid=%d, "
-                            "job_uuid=%d).\n",
+                            "Starting command job %d (pid=%d) for user %d: '%s'\n",
+                            running_job->job.job_uuid,
                             running_job->job.cmd.pid,
-                            running_job->job.job_uuid);
+                            running_job->job.uid,
+                            running_job->job.msg);
                         /* Tell the waiting job stub to start the desired
                          * process */
                         running_job->job.t_started = time(NULL);
@@ -169,8 +171,8 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
                         break;
                     case JOB_TIMESLOT:
                         RESMAND_INFO(
-                            "Serving time slot request. Sleeping for %d "
-                            "secs.\n",
+                            "Starting timeslot job %d. Sleeping for %ds\n",
+                            running_job->job.job_uuid,
                             running_job->job.timeslot.secs);
                         running_job->job.t_started = time(NULL);
                         running_job->job.timeslot.t_end =

--- a/server/server.c
+++ b/server/server.c
@@ -91,8 +91,6 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
                                      running_job->job.job_uuid);
 
                         free_queued_job(running_job);
-                        running_job = NULL;
-
                         goto try_start;
                     }
                     break;
@@ -100,8 +98,6 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
                 case JOB_CMD: {
                     if (running_job->manually_released) {
                         free_queued_job(running_job);
-                        running_job = NULL;
-
                         goto try_start;
                     }
 
@@ -119,8 +115,6 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
                         /* TODO: Here we could add the finished job to a
                          * persistent database */
                         free_queued_job(running_job);
-                        running_job = NULL;
-
                         goto try_start;  // Skip the timeout to try to start a
                                          // new job.
                     } else {

--- a/server/server.c
+++ b/server/server.c
@@ -68,6 +68,51 @@ int main(void) { /*{{{*/
     }
 } /*}}}*/
 
+void format_duration(const time_t earlier, char* buf, const size_t buflen) {
+    if (buf == NULL || buflen == 0) {
+        return;
+    }
+
+    const time_t now = time(NULL);
+    long long elapsed = now - earlier;
+    if (elapsed <= 0) {
+        snprintf(buf, buflen, "0s");
+        return;
+    }
+
+    const struct {
+        const char* suffix;
+        long long num_seconds;
+    } units[] = {
+        {"d",   86400LL},
+        {"h",   3600LL },
+        {"min", 60LL   },
+        {"s",   1LL    }
+    };
+    constexpr size_t num_units = sizeof(units) / sizeof(units[0]);
+
+    char* p = buf;
+    size_t left = buflen;
+    bool first = true;
+
+    for (size_t i = 0; i < num_units; ++i) {
+        const long long value = elapsed / units[i].num_seconds;
+        if (value == 0 && first) continue;  // Skip too large leading units
+
+        const int n = snprintf(p, left, "%s%lld%s", first ? "" : " ", value,
+                               units[i].suffix);
+        if (n < 0 || (size_t)n >= left) {
+            // Error or truncation; don't bother writing more
+            return;
+        }
+
+        p += n;
+        left -= (size_t)n;
+        elapsed %= units[i].num_seconds;
+        first = false;
+    }
+}
+
 /* The dispatcher is responsible for polling the currently running job (if one
  * exists) to check when it ends. When there is no job (the server is free),
  * then this function begins a new one.
@@ -106,12 +151,15 @@ void* dispatcher(void* args UNUSED) { /*{{{*/
                         perror("poll");
                     } else if (pollfd.revents & POLLIN) {
                         // The job has ended, pidfd became readable
-                        RESMAND_INFO("Command job %d finished\n",
-                                     running_job->job.job_uuid);
                         job_exited = true;
                     }
 
                     if (job_exited || running_job->manually_released) {
+                        char s_time[100];
+                        format_duration(running_job->job.t_started, s_time,
+                                        sizeof(s_time));
+                        RESMAND_INFO("Command job %d finished (duration: %s)\n",
+                                     running_job->job.job_uuid, s_time);
                         free_queued_job(running_job);
                         goto try_start;
                     }

--- a/testclient.sh
+++ b/testclient.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 echo "Submitting 1 (time), while server idle --> should run right away"
-./build/resman time 1 -m "First (time)"
+./build/resman time 1s -m "First (time)"
 sleep 1
 
 echo "Submitting 2 (command), while server idle --> should run right away"
@@ -11,13 +11,13 @@ echo ""
 sleep 1
 
 echo "Submitting 3 (time), while server idle --> should run right away"
-./build/resman time 3 -m "Third (time)"
+./build/resman time 3s -m "Third (time)"
 
 echo "Submitting 4 (command), while server busy --> should go into queue and run eventually"
 ./build/resman run -m "Fourth (command)" -- bash -c 'echo Work: ; for i in {1..5} ; do echo -n $i, ; sleep 1 ; done'
 echo ""
 
 echo "Submitting 5 (time), but server busy --> should return an error message saying as much"
-./build/resman time 1 -m "Fifth (time, but server is busy)"
+./build/resman time 1s -m "Fifth (time, but server is busy)"
 
 echo ""

--- a/testclient.sh
+++ b/testclient.sh
@@ -1,3 +1,23 @@
 #!/usr/bin/env bash
 
-./build/resman run -m "Hello!" -- bash -c 'echo Work: ; for i in {1..20} ; do echo -n $i, ; sleep 2 ; done'
+echo "Submitting 1 (time), while server idle --> should run right away"
+./build/resman time 1 -m "First (time)"
+sleep 1
+
+echo "Submitting 2 (command), while server idle --> should run right away"
+./build/resman run -m "Second (command)" -- bash -c 'echo Work: ; for i in {1..5} ; do echo -n $i, ; sleep 1 ; done'
+echo ""
+# Wait until server has detected job 2 completion
+sleep 1
+
+echo "Submitting 3 (time), while server idle --> should run right away"
+./build/resman time 3 -m "Third (time)"
+
+echo "Submitting 4 (command), while server busy --> should go into queue and run eventually"
+./build/resman run -m "Fourth (command)" -- bash -c 'echo Work: ; for i in {1..5} ; do echo -n $i, ; sleep 1 ; done'
+echo ""
+
+echo "Submitting 5 (time), but server busy --> should return an error message saying as much"
+./build/resman time 1 -m "Fifth (time, but server is busy)"
+
+echo ""


### PR DESCRIPTION
Depends on #30, includes all commits from there. Only the last two commits here are relevant (c88589ed1552baaced69ad093aacc5613606393c and b5d1ff8ddef169997b3d04561030d18e8ca83a8c).

Upon completion, log the wall clock duration of the job to the server log, and some associated cleanups.